### PR TITLE
feat: planner brainstorming, STATE.md panel, auto-delete sessions, ship agent

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -639,6 +639,62 @@ pub async fn session_diff_files(
     }
 }
 
+/// Return the contents of `.tpm/STATE.md` for a session, if it exists.
+pub async fn session_state(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let instances = state.instances.read().await;
+    let inst = match instances.iter().find(|i| i.id == id) {
+        Some(i) => i.clone(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "not_found", "message": "Session not found"})),
+            )
+                .into_response()
+        }
+    };
+    drop(instances);
+
+    let result = tokio::task::spawn_blocking(move || {
+        let candidates = [
+            inst.worktree_info
+                .as_ref()
+                .map(|wt| std::path::PathBuf::from(&wt.main_repo_path).join(".tpm/STATE.md")),
+            Some(std::path::PathBuf::from(&inst.project_path).join(".tpm/STATE.md")),
+        ];
+        for candidate in candidates.into_iter().flatten() {
+            if let Ok(content) = std::fs::read_to_string(&candidate) {
+                return Some(content);
+            }
+        }
+        None
+    })
+    .await;
+
+    match result {
+        Ok(Some(content)) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"content": content})),
+        )
+            .into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not_found", "message": "No STATE.md found"})),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!("session_state panicked: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal", "message": "Internal server error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
 #[derive(Deserialize)]
 pub struct FileDiffQuery {
     pub path: String,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -340,6 +340,7 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(api::session_diff_files),
         )
         .route("/api/sessions/{id}/diff/file", get(api::session_diff_file))
+        .route("/api/sessions/{id}/state", get(api::session_state))
         .route("/api/sessions/{id}/terminal", post(api::ensure_terminal))
         .route(
             "/api/sessions/{id}/container-terminal",

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -287,16 +287,40 @@ impl Session {
 
         let target = format!("{}:^.0", self.name);
 
-        let lines: Vec<&str> = text.lines().collect();
-        for (i, line) in lines.iter().enumerate() {
-            Self::tmux_send(&target, &["-l", line])?;
-            if i < lines.len() - 1 {
-                // ESC + CR: what terminals send for Shift+Enter (inserts newline)
-                Self::tmux_send(&target, &["-H", "1b", "0d"])?;
-            }
+        // Use tmux load-buffer + paste-buffer for reliable multiline delivery.
+        // The previous approach (send-keys -l per line + ESC+CR for newlines)
+        // races with the agent's TUI input handler on long messages: keystrokes
+        // arrive faster than the handler processes them, and the final Enter
+        // fires before the text is captured.
+        let tmp = std::env::temp_dir().join(format!("aoe-send-{}.txt", std::process::id()));
+        std::fs::write(&tmp, text)?;
+
+        let load = std::process::Command::new("tmux")
+            .args(["load-buffer", "-b", "aoe-paste"])
+            .arg(&tmp)
+            .output()?;
+        if !load.status.success() {
+            let _ = std::fs::remove_file(&tmp);
+            bail!(
+                "Failed to load buffer: {}",
+                String::from_utf8_lossy(&load.stderr)
+            );
         }
 
-        // Enter to submit
+        // -p wraps in bracket-paste escape sequences so the agent's TUI
+        // treats newlines as literal text, not as Enter (submit).
+        let paste = std::process::Command::new("tmux")
+            .args(["paste-buffer", "-p", "-b", "aoe-paste", "-d", "-t", &target])
+            .output()?;
+        let _ = std::fs::remove_file(&tmp);
+        if !paste.status.success() {
+            bail!(
+                "Failed to paste buffer: {}",
+                String::from_utf8_lossy(&paste.stderr)
+            );
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
         Self::tmux_send(&target, &["Enter"])?;
 
         Ok(())

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 39;
+const DIALOG_HEIGHT: u16 = 40;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -47,6 +47,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("t", "Toggle Agent/Terminal view"),
                 ("c", "Toggle container/host (sandbox)"),
                 ("D", "Diff view (git changes)"),
+                ("S", "TPM state panel (if .tpm)"),
                 ("H/L", "Resize list panel"),
                 ("o", "Cycle sort forward"),
                 ("Ctrl+o", "Cycle sort backward"),

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 40;
+const DIALOG_HEIGHT: u16 = 41;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -48,6 +48,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("c", "Toggle container/host (sandbox)"),
                 ("D", "Diff view (git changes)"),
                 ("S", "TPM state panel (if .tpm)"),
+                ("J/K", "Scroll state panel"),
                 ("H/L", "Resize list panel"),
                 ("o", "Cycle sort forward"),
                 ("Ctrl+o", "Cycle sort backward"),

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -735,14 +735,14 @@ impl HomeView {
                     self.state_panel_cache.scroll_offset.saturating_sub(3);
             }
             KeyCode::Char('S') => {
-                if let Some(id) = self.selected_session.clone() {
+                if self.show_state_panel {
+                    self.show_state_panel = false;
+                } else if let Some(id) = self.selected_session.clone() {
                     if let Some(inst) = self.get_instance(&id).cloned() {
                         if super::state_panel::StatePanelCache::exists_for(&inst) {
-                            self.show_state_panel = !self.show_state_panel;
-                            if self.show_state_panel {
-                                self.state_panel_cache.refresh_if_needed(&inst);
-                                self.state_panel_cache.reset_scroll();
-                            }
+                            self.show_state_panel = true;
+                            self.state_panel_cache.refresh_if_needed(&inst);
+                            self.state_panel_cache.reset_scroll();
                         }
                     }
                 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -725,17 +725,25 @@ impl HomeView {
                     }
                 }
             }
+            // Scroll the state panel when visible
+            KeyCode::Char('J') if self.show_state_panel => {
+                self.state_panel_cache.scroll_offset =
+                    self.state_panel_cache.scroll_offset.saturating_add(3);
+            }
+            KeyCode::Char('K') if self.show_state_panel => {
+                self.state_panel_cache.scroll_offset =
+                    self.state_panel_cache.scroll_offset.saturating_sub(3);
+            }
             KeyCode::Char('S') => {
-                // Toggle TPM STATE.md panel for the selected session
                 if let Some(id) = self.selected_session.clone() {
                     if let Some(inst) = self.get_instance(&id).cloned() {
                         if super::state_panel::StatePanelCache::exists_for(&inst) {
                             self.show_state_panel = !self.show_state_panel;
                             if self.show_state_panel {
                                 self.state_panel_cache.refresh_if_needed(&inst);
+                                self.state_panel_cache.reset_scroll();
                             }
                         }
-                        // Non-TPM sessions: pressing S does nothing (AC-03)
                     }
                 }
             }
@@ -1051,14 +1059,20 @@ impl HomeView {
         if let Some(item) = self.flat_items.get(self.cursor) {
             match item {
                 Item::Session { id, .. } => {
+                    let changed = self.selected_session.as_deref() != Some(id.as_str());
                     self.selected_session = Some(id.clone());
                     self.selected_group = None;
                     self.selected_group_profile = None;
+                    if changed {
+                        self.show_state_panel = false;
+                        self.state_panel_cache.reset_scroll();
+                    }
                 }
                 Item::Group { path, .. } => {
                     self.selected_session = None;
                     self.selected_group = Some(path.clone());
                     self.selected_group_profile = self.profile_for_cursor(self.cursor);
+                    self.show_state_panel = false;
                 }
             }
         }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -725,6 +725,20 @@ impl HomeView {
                     }
                 }
             }
+            KeyCode::Char('S') => {
+                // Toggle TPM STATE.md panel for the selected session
+                if let Some(id) = self.selected_session.clone() {
+                    if let Some(inst) = self.get_instance(&id).cloned() {
+                        if super::state_panel::StatePanelCache::exists_for(&inst) {
+                            self.show_state_panel = !self.show_state_panel;
+                            if self.show_state_panel {
+                                self.state_panel_cache.refresh_if_needed(&inst);
+                            }
+                        }
+                        // Non-TPM sessions: pressing S does nothing (AC-03)
+                    }
+                }
+            }
             KeyCode::Char('D') => {
                 // Open diff view - requires a selected session
                 let Some(session_id) = &self.selected_session else {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3,6 +3,7 @@
 mod input;
 mod operations;
 mod render;
+pub(super) mod state_panel;
 
 #[cfg(test)]
 mod tests;
@@ -227,6 +228,10 @@ pub struct HomeView {
 
     // Resizable list column width (percentage-like units)
     pub(super) list_width: u16,
+
+    // TPM STATE.md panel
+    pub(super) show_state_panel: bool,
+    pub(super) state_panel_cache: state_panel::StatePanelCache,
 }
 
 impl HomeView {
@@ -361,6 +366,8 @@ impl HomeView {
             list_width: user_config
                 .and_then(|c| c.app_state.home_list_width)
                 .unwrap_or(35),
+            show_state_panel: false,
+            state_panel_cache: state_panel::StatePanelCache::default(),
         };
 
         // Clean up orphaned Creating instances from a prior crash

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -896,11 +896,22 @@ impl HomeView {
 
         // Show S: State hint when a TPM session is selected (uses cached path, no fs stat)
         if self.selected_session.is_some() && self.state_panel_cache.has_state_file() {
-            spans.extend([
-                Span::styled("│", sep_style),
-                Span::styled(" S", key_style),
-                Span::styled(" State ", desc_style),
-            ]);
+            if self.show_state_panel {
+                spans.extend([
+                    Span::styled("│", sep_style),
+                    Span::styled(" S", key_style),
+                    Span::styled(" Close ", desc_style),
+                    Span::styled("│", sep_style),
+                    Span::styled(" J/K", key_style),
+                    Span::styled(" Scroll ", desc_style),
+                ]);
+            } else {
+                spans.extend([
+                    Span::styled("│", sep_style),
+                    Span::styled(" S", key_style),
+                    Span::styled(" State ", desc_style),
+                ]);
+            }
         }
 
         spans.extend([

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -104,7 +104,42 @@ impl HomeView {
             .split(main_chunks[0]);
 
         self.render_list(frame, chunks[0], theme);
-        self.render_preview(frame, chunks[1], theme);
+
+        // If the state panel is visible, split the right area between preview and state
+        if self.show_state_panel && self.state_panel_cache.has_content() {
+            // Refresh cache for the selected session
+            if let Some(id) = &self.selected_session {
+                if let Some(inst) = self.get_instance(id) {
+                    let inst = inst.clone();
+                    self.state_panel_cache.refresh_if_needed(&inst);
+                }
+            }
+
+            let right_chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                .split(chunks[1]);
+
+            self.render_preview(frame, right_chunks[0], theme);
+            super::state_panel::render_state_panel(
+                frame,
+                right_chunks[1],
+                &self.state_panel_cache.content.clone(),
+                theme,
+            );
+        } else {
+            // Refresh cache in background even when panel is hidden (for poll)
+            if self.show_state_panel {
+                if let Some(id) = &self.selected_session {
+                    if let Some(inst) = self.get_instance(id) {
+                        let inst = inst.clone();
+                        self.state_panel_cache.refresh_if_needed(&inst);
+                    }
+                }
+            }
+            self.render_preview(frame, chunks[1], theme);
+        }
+
         self.render_status_bar(frame, main_chunks[1], theme);
 
         if let Some(info) = update_info {
@@ -855,6 +890,19 @@ impl HomeView {
                 Span::styled(" d", key_style),
                 Span::styled(" Del ", desc_style),
             ]);
+        }
+
+        // Show S: State hint when a TPM session is selected
+        if let Some(id) = &self.selected_session {
+            if let Some(inst) = self.get_instance(id) {
+                if super::state_panel::StatePanelCache::exists_for(inst) {
+                    spans.extend([
+                        Span::styled("│", sep_style),
+                        Span::styled(" S", key_style),
+                        Span::styled(" State ", desc_style),
+                    ]);
+                }
+            }
         }
 
         spans.extend([

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -121,11 +121,13 @@ impl HomeView {
                 .split(chunks[1]);
 
             self.render_preview(frame, right_chunks[0], theme);
+            let scroll = self.state_panel_cache.scroll_offset;
             super::state_panel::render_state_panel(
                 frame,
                 right_chunks[1],
-                &self.state_panel_cache.content.clone(),
+                &self.state_panel_cache.content,
                 theme,
+                scroll,
             );
         } else {
             // Refresh cache in background even when panel is hidden (for poll)
@@ -892,17 +894,13 @@ impl HomeView {
             ]);
         }
 
-        // Show S: State hint when a TPM session is selected
-        if let Some(id) = &self.selected_session {
-            if let Some(inst) = self.get_instance(id) {
-                if super::state_panel::StatePanelCache::exists_for(inst) {
-                    spans.extend([
-                        Span::styled("│", sep_style),
-                        Span::styled(" S", key_style),
-                        Span::styled(" State ", desc_style),
-                    ]);
-                }
-            }
+        // Show S: State hint when a TPM session is selected (uses cached path, no fs stat)
+        if self.selected_session.is_some() && self.state_panel_cache.has_state_file() {
+            spans.extend([
+                Span::styled("│", sep_style),
+                Span::styled(" S", key_style),
+                Span::styled(" State ", desc_style),
+            ]);
         }
 
         spans.extend([

--- a/src/tui/home/state_panel.rs
+++ b/src/tui/home/state_panel.rs
@@ -197,26 +197,20 @@ fn parse_state_md(content: &str, theme: &Theme, width: usize) -> Vec<Line<'stati
 
         // Headers (check longest prefix first)
         if let Some(rest) = trimmed.strip_prefix("### ") {
-            lines.push(Line::from(Span::styled(
-                rest.to_string(),
-                Style::default().fg(theme.text).bold().italic(),
-            )));
+            let style = Style::default().fg(theme.text).bold().italic();
+            lines.extend(wrap_line(rest, style, width, "  "));
             i += 1;
             continue;
         }
         if let Some(rest) = trimmed.strip_prefix("## ") {
-            lines.push(Line::from(Span::styled(
-                rest.to_string(),
-                Style::default().fg(theme.title).bold(),
-            )));
+            let style = Style::default().fg(theme.title).bold();
+            lines.extend(wrap_line(rest, style, width, "  "));
             i += 1;
             continue;
         }
         if let Some(rest) = trimmed.strip_prefix("# ") {
-            lines.push(Line::from(Span::styled(
-                rest.to_string(),
-                Style::default().fg(theme.title).bold(),
-            )));
+            let style = Style::default().fg(theme.title).bold();
+            lines.extend(wrap_line(rest, style, width, "  "));
             i += 1;
             continue;
         }
@@ -237,15 +231,10 @@ fn parse_state_md(content: &str, theme: &Theme, width: usize) -> Vec<Line<'stati
             }
 
             let cells = parse_table_row(trimmed);
-            let is_header =
-                i > 0 && i + 1 < raw_lines.len() && is_table_separator(raw_lines[i + 1].trim());
-            // Also treat as header if this is the first row of the table
-            let is_first_row = in_table
-                && (i == 0
-                    || !raw_lines[i - 1].trim().starts_with('|')
-                    || is_table_separator(raw_lines[i - 1].trim()));
+            // A row is a header only if the next line is a separator
+            let is_header = i + 1 < raw_lines.len() && is_table_separator(raw_lines[i + 1].trim());
 
-            let styled_cells = if is_header || is_first_row {
+            let styled_cells = if is_header {
                 render_table_header(&cells, &col_widths, theme)
             } else {
                 render_table_row(&cells, &col_widths, theme)
@@ -272,16 +261,16 @@ fn parse_state_md(content: &str, theme: &Theme, width: usize) -> Vec<Line<'stati
         // Bullet points
         if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
             let bullet_content = &trimmed[2..];
-            lines.push(render_inline_styled(
-                &format!("  \u{2022} {}", bullet_content),
-                theme,
-            ));
+            let text = format!("  \u{2022} {}", bullet_content);
+            let style = Style::default().fg(theme.text);
+            lines.extend(wrap_line(&text, style, width, "    "));
             i += 1;
             continue;
         }
 
-        // Regular text with inline status highlighting
-        lines.push(render_inline_styled(trimmed, theme));
+        // Regular text
+        let style = Style::default().fg(theme.text);
+        lines.extend(wrap_line(trimmed, style, width, ""));
         i += 1;
     }
 
@@ -425,12 +414,55 @@ fn status_color_for_cell(text: &str, theme: &Theme) -> Style {
     Style::default().fg(theme.text)
 }
 
-/// Render a line of plain text (prose, bullets). No status coloring.
-fn render_inline_styled(text: &str, theme: &Theme) -> Line<'static> {
-    Line::from(Span::styled(
-        text.to_string(),
-        Style::default().fg(theme.text),
-    ))
+/// Soft-wrap a single logical line into multiple display Lines.
+/// `indent` is prepended to continuation lines (e.g. "    " for bullets).
+fn wrap_line(text: &str, style: Style, width: usize, indent: &str) -> Vec<Line<'static>> {
+    if width == 0 || text.is_empty() {
+        return vec![Line::from(Span::styled(text.to_string(), style))];
+    }
+
+    let mut result = Vec::new();
+    let mut remaining = text;
+    let mut first = true;
+
+    while !remaining.is_empty() {
+        let max = if first {
+            width
+        } else {
+            width.saturating_sub(indent.len())
+        };
+        if remaining.len() <= max {
+            let line_text = if first {
+                remaining.to_string()
+            } else {
+                format!("{}{}", indent, remaining)
+            };
+            result.push(Line::from(Span::styled(line_text, style)));
+            break;
+        }
+
+        // Find a word boundary to break at
+        let break_at = remaining[..max]
+            .rfind(' ')
+            .map(|pos| pos + 1)
+            .unwrap_or(max);
+
+        let (chunk, rest) = remaining.split_at(break_at);
+        let line_text = if first {
+            chunk.trim_end().to_string()
+        } else {
+            format!("{}{}", indent, chunk.trim_end())
+        };
+        result.push(Line::from(Span::styled(line_text, style)));
+        remaining = rest.trim_start();
+        first = false;
+    }
+
+    if result.is_empty() {
+        result.push(Line::from(Span::styled(String::new(), style)));
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -506,6 +538,63 @@ mod tests {
         let theme = Theme::default();
         let lines = parse_state_md("", &theme, 80);
         assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn test_wrap_line_short() {
+        let style = Style::default();
+        let result = wrap_line("hello world", style, 80, "");
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_wrap_line_long() {
+        let style = Style::default();
+        let result = wrap_line("this is a longer sentence that should wrap", style, 20, "");
+        assert!(result.len() > 1);
+        // Each line should fit within width
+        for line in &result {
+            assert!(line.width() <= 20);
+        }
+    }
+
+    #[test]
+    fn test_wrap_line_with_indent() {
+        let style = Style::default();
+        let result = wrap_line(
+            "  • some bullet text that is long enough to wrap around",
+            style,
+            25,
+            "    ",
+        );
+        assert!(result.len() > 1);
+        // Continuation lines get indented
+        if result.len() > 1 {
+            let second = &result[1];
+            let text = second
+                .spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>();
+            assert!(text.starts_with("    "));
+        }
+    }
+
+    #[test]
+    fn test_first_data_row_not_bold() {
+        let content = "| Task | Status |\n|---|---|\n| task-01 | done |\n| task-02 | done |\n";
+        let theme = Theme::default();
+        let lines = parse_state_md(content, &theme, 80);
+        // Header (bold) + 2 data rows (not bold)
+        assert_eq!(lines.len(), 3);
+        // First data row should NOT be bold
+        let first_data = &lines[1];
+        for span in &first_data.spans {
+            assert!(
+                !span.style.add_modifier.contains(Modifier::BOLD),
+                "First data row should not be bold"
+            );
+        }
     }
 
     #[test]

--- a/src/tui/home/state_panel.rs
+++ b/src/tui/home/state_panel.rs
@@ -27,6 +27,8 @@ pub(in crate::tui) struct StatePanelCache {
     last_poll: Instant,
     /// Resolved path to the STATE.md file (None = not yet resolved).
     resolved_path: Option<PathBuf>,
+    /// Scroll offset for the TUI panel.
+    pub(super) scroll_offset: usize,
 }
 
 impl Default for StatePanelCache {
@@ -36,6 +38,7 @@ impl Default for StatePanelCache {
             content: String::new(),
             last_poll: Instant::now(),
             resolved_path: None,
+            scroll_offset: 0,
         }
     }
 }
@@ -107,9 +110,20 @@ impl StatePanelCache {
         !self.content.is_empty()
     }
 
-    /// Check if a STATE.md exists for the given instance without caching.
+    /// Whether a STATE.md path has been resolved (cached, no filesystem stat).
+    pub(super) fn has_state_file(&self) -> bool {
+        self.resolved_path.is_some()
+    }
+
+    /// Check if a STATE.md exists for the given instance (does filesystem stat).
+    /// Use sparingly; prefer `has_state_file()` for hot paths like rendering.
     pub(super) fn exists_for(inst: &Instance) -> bool {
         Self::resolve_path(inst).is_some()
+    }
+
+    /// Reset scroll offset to zero.
+    pub(super) fn reset_scroll(&mut self) {
+        self.scroll_offset = 0;
     }
 }
 
@@ -119,6 +133,7 @@ pub(in crate::tui) fn render_state_panel(
     area: Rect,
     content: &str,
     theme: &Theme,
+    scroll_offset: usize,
 ) {
     let block = Block::default()
         .borders(Borders::ALL)
@@ -132,12 +147,32 @@ pub(in crate::tui) fn render_state_panel(
     frame.render_widget(block, area);
 
     let lines = parse_state_md(content, theme, inner.width as usize);
-
-    // Simple vertical scroll: show as many lines as fit
+    let total = lines.len();
     let visible = inner.height as usize;
-    let display_lines: Vec<Line> = lines.into_iter().take(visible).collect();
+
+    let clamped_offset = scroll_offset.min(total.saturating_sub(visible));
+    let display_lines: Vec<Line> = lines
+        .into_iter()
+        .skip(clamped_offset)
+        .take(visible)
+        .collect();
 
     frame.render_widget(Paragraph::new(display_lines), inner);
+
+    // Truncation indicator when content overflows
+    if total > visible && clamped_offset + visible < total {
+        let indicator = Span::styled(
+            format!(" ▼ {}/{} ", clamped_offset + visible, total),
+            Style::default().fg(theme.dimmed),
+        );
+        let indicator_area = Rect {
+            x: area.x + 2,
+            y: area.y + area.height.saturating_sub(1),
+            width: area.width.saturating_sub(4).min(20),
+            height: 1,
+        };
+        frame.render_widget(Paragraph::new(Line::from(indicator)), indicator_area);
+    }
 }
 
 /// Parse STATE.md markdown into styled ratatui Lines.
@@ -248,13 +283,19 @@ fn parse_state_md(content: &str, theme: &Theme, width: usize) -> Vec<Line<'stati
     lines
 }
 
-/// Check if a table line is a separator (e.g., |---|---|)
+/// Check if a table line is a separator (e.g., |---|---|).
+/// Each cell segment must contain at least 3 dashes.
 fn is_table_separator(line: &str) -> bool {
-    let inner = line.trim_matches('|').trim();
-    !inner.is_empty()
-        && inner
-            .chars()
-            .all(|c| c == '-' || c == '|' || c == ':' || c == ' ')
+    let trimmed = line.trim();
+    let stripped = trimmed.strip_prefix('|').unwrap_or(trimmed);
+    let inner = stripped.strip_suffix('|').unwrap_or(stripped);
+    if inner.is_empty() {
+        return false;
+    }
+    inner.split('|').all(|segment| {
+        let seg = segment.trim().trim_matches(':');
+        seg.len() >= 3 && seg.chars().all(|c| c == '-')
+    })
 }
 
 /// Parse a table row into cells.
@@ -288,9 +329,13 @@ fn compute_table_col_widths(table_lines: &[&str], max_width: usize) -> Vec<usize
         }
     }
 
+    if widths.is_empty() {
+        return widths;
+    }
+
     // Clamp total width
     let total: usize = widths.iter().sum::<usize>() + widths.len().saturating_sub(1) * 3;
-    if total > max_width && !widths.is_empty() {
+    if total > max_width {
         let scale = max_width as f64 / total as f64;
         for w in &mut widths {
             *w = ((*w as f64) * scale).max(3.0) as usize;
@@ -375,12 +420,12 @@ fn status_color_for_cell(text: &str, theme: &Theme) -> Style {
     Style::default().fg(theme.text)
 }
 
-/// Render a line of text with inline status keyword highlighting.
+/// Render a line of plain text (prose, bullets). No status coloring.
 fn render_inline_styled(text: &str, theme: &Theme) -> Line<'static> {
-    // Simple approach: apply status color to the whole line if it contains
-    // a status keyword, otherwise use default text color
-    let style = status_color_for_cell(text, theme);
-    Line::from(Span::styled(text.to_string(), style))
+    Line::from(Span::styled(
+        text.to_string(),
+        Style::default().fg(theme.text),
+    ))
 }
 
 #[cfg(test)]
@@ -392,8 +437,12 @@ mod tests {
         assert!(is_table_separator("|---|---|"));
         assert!(is_table_separator("| --- | --- |"));
         assert!(is_table_separator("|:---|---:|"));
+        assert!(is_table_separator("|:---:|:---:|"));
         assert!(!is_table_separator("| foo | bar |"));
         assert!(!is_table_separator("not a table"));
+        // Requires at least 3 dashes per segment
+        assert!(!is_table_separator("|-|-|"));
+        assert!(!is_table_separator("|--|--|"));
     }
 
     #[test]

--- a/src/tui/home/state_panel.rs
+++ b/src/tui/home/state_panel.rs
@@ -99,6 +99,11 @@ impl StatePanelCache {
 
         if new_content != self.content {
             self.content = new_content;
+            // Clamp scroll offset to new content length
+            let line_count = self.content.lines().count();
+            if self.scroll_offset > line_count {
+                self.scroll_offset = line_count.saturating_sub(1);
+            }
             true
         } else {
             false

--- a/src/tui/home/state_panel.rs
+++ b/src/tui/home/state_panel.rs
@@ -1,0 +1,463 @@
+//! STATE.md side panel for TPM sessions
+//!
+//! Renders the contents of `.tpm/STATE.md` (relative to the session's project
+//! or worktree main-repo path) as styled text in a right-side TUI panel.
+//! The panel is toggled with `S` and auto-refreshes by polling the file every
+//! 2-3 seconds.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+
+use crate::session::Instance;
+use crate::tui::styles::Theme;
+
+/// Interval between STATE.md re-reads (seconds).
+const POLL_INTERVAL_SECS: u64 = 2;
+
+/// Cached STATE.md content and metadata.
+pub(in crate::tui) struct StatePanelCache {
+    /// Session ID this cache belongs to (invalidated on session switch).
+    session_id: Option<String>,
+    /// Raw file content (empty if file missing).
+    pub(super) content: String,
+    /// When we last read the file from disk.
+    last_poll: Instant,
+    /// Resolved path to the STATE.md file (None = not yet resolved).
+    resolved_path: Option<PathBuf>,
+}
+
+impl Default for StatePanelCache {
+    fn default() -> Self {
+        Self {
+            session_id: None,
+            content: String::new(),
+            last_poll: Instant::now(),
+            resolved_path: None,
+        }
+    }
+}
+
+impl StatePanelCache {
+    /// Resolve the STATE.md path for an instance. Checks the worktree
+    /// main_repo_path first (so all branches of the same repo share one
+    /// STATE.md), then falls back to project_path.
+    fn resolve_path(inst: &Instance) -> Option<PathBuf> {
+        // Try worktree main repo path first
+        if let Some(wt) = &inst.worktree_info {
+            let p = Path::new(&wt.main_repo_path).join(".tpm/STATE.md");
+            if p.exists() {
+                return Some(p);
+            }
+        }
+
+        // Try project_path
+        let p = Path::new(&inst.project_path).join(".tpm/STATE.md");
+        if p.exists() {
+            return Some(p);
+        }
+
+        None
+    }
+
+    /// Refresh the cache if the session changed or the poll interval elapsed.
+    /// Returns true if the content actually changed.
+    pub(super) fn refresh_if_needed(&mut self, inst: &Instance) -> bool {
+        let session_changed = self.session_id.as_deref() != Some(&inst.id);
+
+        if session_changed {
+            self.session_id = Some(inst.id.clone());
+            self.resolved_path = Self::resolve_path(inst);
+            self.content.clear();
+            self.last_poll = Instant::now()
+                .checked_sub(std::time::Duration::from_secs(POLL_INTERVAL_SECS + 1))
+                .unwrap_or_else(Instant::now);
+        }
+
+        let elapsed = self.last_poll.elapsed().as_secs();
+        if elapsed < POLL_INTERVAL_SECS && !session_changed {
+            return false;
+        }
+
+        self.last_poll = Instant::now();
+
+        // Re-resolve path periodically (STATE.md may appear/disappear)
+        if elapsed >= POLL_INTERVAL_SECS * 3 || session_changed {
+            self.resolved_path = Self::resolve_path(inst);
+        }
+
+        let new_content = self
+            .resolved_path
+            .as_ref()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .unwrap_or_default();
+
+        if new_content != self.content {
+            self.content = new_content;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether there is STATE.md content to show.
+    pub(super) fn has_content(&self) -> bool {
+        !self.content.is_empty()
+    }
+
+    /// Check if a STATE.md exists for the given instance without caching.
+    pub(super) fn exists_for(inst: &Instance) -> bool {
+        Self::resolve_path(inst).is_some()
+    }
+}
+
+/// Render the STATE.md panel into the given area.
+pub(in crate::tui) fn render_state_panel(
+    frame: &mut Frame,
+    area: Rect,
+    content: &str,
+    theme: &Theme,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.accent))
+        .title(" TPM State ")
+        .title_style(Style::default().fg(theme.accent).bold())
+        .padding(Padding::horizontal(1));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let lines = parse_state_md(content, theme, inner.width as usize);
+
+    // Simple vertical scroll: show as many lines as fit
+    let visible = inner.height as usize;
+    let display_lines: Vec<Line> = lines.into_iter().take(visible).collect();
+
+    frame.render_widget(Paragraph::new(display_lines), inner);
+}
+
+/// Parse STATE.md markdown into styled ratatui Lines.
+fn parse_state_md(content: &str, theme: &Theme, width: usize) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Detect if we're inside a markdown table
+    let mut in_table = false;
+    let mut col_widths: Vec<usize> = Vec::new();
+
+    let raw_lines: Vec<&str> = content.lines().collect();
+    let mut i = 0;
+
+    while i < raw_lines.len() {
+        let line = raw_lines[i];
+        let trimmed = line.trim();
+
+        // Headers (check longest prefix first)
+        if let Some(rest) = trimmed.strip_prefix("### ") {
+            lines.push(Line::from(Span::styled(
+                rest.to_string(),
+                Style::default().fg(theme.text).bold().italic(),
+            )));
+            i += 1;
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("## ") {
+            lines.push(Line::from(Span::styled(
+                rest.to_string(),
+                Style::default().fg(theme.title).bold(),
+            )));
+            i += 1;
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("# ") {
+            lines.push(Line::from(Span::styled(
+                rest.to_string(),
+                Style::default().fg(theme.title).bold(),
+            )));
+            i += 1;
+            continue;
+        }
+
+        // Table detection: line starts with | and contains at least one more |
+        if trimmed.starts_with('|') && trimmed.matches('|').count() >= 2 {
+            if !in_table {
+                in_table = true;
+                col_widths.clear();
+                // Scan ahead to compute column widths for alignment
+                col_widths = compute_table_col_widths(&raw_lines[i..], width);
+            }
+
+            // Skip separator rows (|---|---|)
+            if is_table_separator(trimmed) {
+                i += 1;
+                continue;
+            }
+
+            let cells = parse_table_row(trimmed);
+            let is_header =
+                i > 0 && i + 1 < raw_lines.len() && is_table_separator(raw_lines[i + 1].trim());
+            // Also treat as header if this is the first row of the table
+            let is_first_row = in_table
+                && (i == 0
+                    || !raw_lines[i - 1].trim().starts_with('|')
+                    || is_table_separator(raw_lines[i - 1].trim()));
+
+            let styled_cells = if is_header || is_first_row {
+                render_table_header(&cells, &col_widths, theme)
+            } else {
+                render_table_row(&cells, &col_widths, theme)
+            };
+
+            lines.push(styled_cells);
+            i += 1;
+            continue;
+        }
+
+        // End of table
+        if in_table {
+            in_table = false;
+            col_widths.clear();
+        }
+
+        // Empty line
+        if trimmed.is_empty() {
+            lines.push(Line::from(""));
+            i += 1;
+            continue;
+        }
+
+        // Bullet points
+        if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
+            let bullet_content = &trimmed[2..];
+            lines.push(render_inline_styled(
+                &format!("  \u{2022} {}", bullet_content),
+                theme,
+            ));
+            i += 1;
+            continue;
+        }
+
+        // Regular text with inline status highlighting
+        lines.push(render_inline_styled(trimmed, theme));
+        i += 1;
+    }
+
+    lines
+}
+
+/// Check if a table line is a separator (e.g., |---|---|)
+fn is_table_separator(line: &str) -> bool {
+    let inner = line.trim_matches('|').trim();
+    !inner.is_empty()
+        && inner
+            .chars()
+            .all(|c| c == '-' || c == '|' || c == ':' || c == ' ')
+}
+
+/// Parse a table row into cells.
+fn parse_table_row(line: &str) -> Vec<String> {
+    let trimmed = line.trim();
+    // Strip leading and trailing pipes
+    let stripped = trimmed.strip_prefix('|').unwrap_or(trimmed);
+    let inner = stripped.strip_suffix('|').unwrap_or(stripped);
+
+    inner.split('|').map(|s| s.trim().to_string()).collect()
+}
+
+/// Compute column widths by scanning all rows of a table block.
+fn compute_table_col_widths(table_lines: &[&str], max_width: usize) -> Vec<usize> {
+    let mut widths: Vec<usize> = Vec::new();
+
+    for line in table_lines {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') {
+            break;
+        }
+        if is_table_separator(trimmed) {
+            continue;
+        }
+        let cells = parse_table_row(trimmed);
+        if widths.len() < cells.len() {
+            widths.resize(cells.len(), 0);
+        }
+        for (j, cell) in cells.iter().enumerate() {
+            widths[j] = widths[j].max(cell.len());
+        }
+    }
+
+    // Clamp total width
+    let total: usize = widths.iter().sum::<usize>() + widths.len().saturating_sub(1) * 3;
+    if total > max_width && !widths.is_empty() {
+        let scale = max_width as f64 / total as f64;
+        for w in &mut widths {
+            *w = ((*w as f64) * scale).max(3.0) as usize;
+        }
+    }
+
+    widths
+}
+
+/// Render a table header row with bold styling.
+fn render_table_header(cells: &[String], col_widths: &[usize], theme: &Theme) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+
+    for (j, cell) in cells.iter().enumerate() {
+        let w = col_widths.get(j).copied().unwrap_or(cell.len());
+        let padded = format!("{:<width$}", cell, width = w);
+
+        spans.push(Span::styled(
+            padded,
+            Style::default().fg(theme.title).bold(),
+        ));
+
+        if j < cells.len() - 1 {
+            spans.push(Span::styled(
+                " \u{2502} ",
+                Style::default().fg(theme.border),
+            ));
+        }
+    }
+
+    Line::from(spans)
+}
+
+/// Render a table data row with status-aware coloring.
+fn render_table_row(cells: &[String], col_widths: &[usize], theme: &Theme) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+
+    for (j, cell) in cells.iter().enumerate() {
+        let w = col_widths.get(j).copied().unwrap_or(cell.len());
+        let padded = format!("{:<width$}", cell, width = w);
+
+        let style = status_color_for_cell(cell, theme);
+        spans.push(Span::styled(padded, style));
+
+        if j < cells.len() - 1 {
+            spans.push(Span::styled(
+                " \u{2502} ",
+                Style::default().fg(theme.border),
+            ));
+        }
+    }
+
+    Line::from(spans)
+}
+
+/// Map status-like text in a cell to a color.
+fn status_color_for_cell(text: &str, theme: &Theme) -> Style {
+    let lower = text.trim().to_lowercase();
+
+    // Check for status keywords
+    if lower.contains("done") || lower.contains("completed") || lower.contains("\u{2705}") {
+        return Style::default().fg(theme.running); // green
+    }
+    if lower.contains("implementing")
+        || lower.contains("in_progress")
+        || lower.contains("in-progress")
+        || lower.contains("running")
+        || lower.contains("\u{1f7e1}")
+    {
+        return Style::default().fg(theme.waiting); // yellow
+    }
+    if lower.contains("reviewing") || lower.contains("pending") {
+        return Style::default().fg(theme.accent);
+    }
+    if lower.contains("blocked") || lower.contains("failed") || lower.contains("\u{274c}") {
+        return Style::default().fg(theme.error); // red
+    }
+    if lower.contains("not-started") || lower.contains("not_started") || lower.contains("skipped") {
+        return Style::default().fg(theme.dimmed);
+    }
+
+    Style::default().fg(theme.text)
+}
+
+/// Render a line of text with inline status keyword highlighting.
+fn render_inline_styled(text: &str, theme: &Theme) -> Line<'static> {
+    // Simple approach: apply status color to the whole line if it contains
+    // a status keyword, otherwise use default text color
+    let style = status_color_for_cell(text, theme);
+    Line::from(Span::styled(text.to_string(), style))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_table_separator() {
+        assert!(is_table_separator("|---|---|"));
+        assert!(is_table_separator("| --- | --- |"));
+        assert!(is_table_separator("|:---|---:|"));
+        assert!(!is_table_separator("| foo | bar |"));
+        assert!(!is_table_separator("not a table"));
+    }
+
+    #[test]
+    fn test_parse_table_row() {
+        let cells = parse_table_row("| foo | bar | baz |");
+        assert_eq!(cells, vec!["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn test_parse_table_row_no_trailing_pipe() {
+        let cells = parse_table_row("| foo | bar");
+        assert_eq!(cells, vec!["foo", "bar"]);
+    }
+
+    #[test]
+    fn test_status_color_detection() {
+        let theme = Theme::default();
+
+        // "done" should get running (green) color
+        let style = status_color_for_cell("done", &theme);
+        assert_eq!(style.fg, Some(theme.running));
+
+        // "implementing" should get waiting (yellow) color
+        let style = status_color_for_cell("implementing", &theme);
+        assert_eq!(style.fg, Some(theme.waiting));
+
+        // "not-started" should get dimmed color
+        let style = status_color_for_cell("not-started", &theme);
+        assert_eq!(style.fg, Some(theme.dimmed));
+
+        // Regular text should get text color
+        let style = status_color_for_cell("hello world", &theme);
+        assert_eq!(style.fg, Some(theme.text));
+    }
+
+    #[test]
+    fn test_parse_state_md_headers() {
+        let content = "# Title\n## Section\n### Subsection\n";
+        let theme = Theme::default();
+        let lines = parse_state_md(content, &theme, 80);
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_state_md_table() {
+        let content =
+            "| Task | Status |\n|---|---|\n| task-01 | done |\n| task-02 | implementing |\n";
+        let theme = Theme::default();
+        let lines = parse_state_md(content, &theme, 80);
+        // Header + 2 data rows (separator skipped)
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_state_md_empty() {
+        let theme = Theme::default();
+        let lines = parse_state_md("", &theme, 80);
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn test_compute_col_widths() {
+        let table = vec!["| foo | barbaz |", "|---|---|", "| a | b |"];
+        let widths = compute_table_col_widths(&table, 80);
+        assert_eq!(widths, vec![3, 6]); // "foo"=3, "barbaz"=6
+    }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -211,6 +211,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         },
         onHelp: () => setShowHelp((h) => !h),
         onSettings: () => setShowSettings((s) => !s),
+        onToggleState: () => setShowStatePanel((s) => !s),
         onPalette: () => setShowPalette((p) => !p),
       }),
       [toggleDiff, showPalette],
@@ -317,6 +318,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         loginRequired={loginRequired}
         isOffline={!!error}
         onGoDashboard={handleGoDashboard}
+        onToggleStatePanel={() => setShowStatePanel((s) => !s)}
+        statePanelOpen={showStatePanel}
       />
 
       <div className="flex flex-1 min-h-0">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { SettingsView } from "./components/SettingsView";
 import { HelpOverlay } from "./components/HelpOverlay";
 import { SessionWizard } from "./components/session-wizard/SessionWizard";
 import { Dashboard } from "./components/Dashboard";
+import { StatePanel } from "./components/StatePanel";
 import { LoginPage } from "./components/LoginPage";
 import { AboutModal } from "./components/AboutModal";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
@@ -71,6 +72,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [showSettings, setShowSettings] = useState(false);
   const [showPalette, setShowPalette] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
+  const [showStatePanel, setShowStatePanel] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(
     () => window.innerWidth >= 768,
   );
@@ -251,6 +253,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         <ContentSplit
           collapsed={diffCollapsed}
           onToggleCollapse={toggleDiff}
+          statePanel={
+            showStatePanel ? (
+              <StatePanel
+                session={activeSession ?? null}
+                onClose={() => setShowStatePanel(false)}
+              />
+            ) : undefined
+          }
           left={
             <div className="flex-1 flex flex-col min-h-0 overflow-hidden relative">
               <div

--- a/web/src/components/ContentSplit.tsx
+++ b/web/src/components/ContentSplit.tsx
@@ -10,6 +10,8 @@ interface Props {
   right: React.ReactNode;
   collapsed: boolean;
   onToggleCollapse: () => void;
+  /** Optional extra panel rendered between left and right (e.g. TPM state panel). */
+  statePanel?: React.ReactNode;
 }
 
 function loadSavedWidth(): number {
@@ -30,6 +32,7 @@ export function ContentSplit({
   right,
   collapsed,
   onToggleCollapse,
+  statePanel,
 }: Props) {
   const [diffWidth, setDiffWidth] = useState(loadSavedWidth);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -88,6 +91,9 @@ export function ContentSplit({
     <div ref={containerRef} className="flex-1 flex min-h-0 overflow-hidden relative">
       {/* Terminal pane */}
       <div className="flex-1 flex flex-col min-w-0 min-h-0">{left}</div>
+
+      {/* Optional state panel (TPM sessions) */}
+      {statePanel}
 
       {!collapsed && (
         <>

--- a/web/src/components/StatePanel.tsx
+++ b/web/src/components/StatePanel.tsx
@@ -54,10 +54,16 @@ function statusClass(text: string): string {
   return "text-text-secondary";
 }
 
-/** Check if a table line is a separator row. */
+/** Check if a table line is a separator row. Each segment must have >= 3 dashes. */
 function isTableSeparator(line: string): boolean {
-  const inner = line.replace(/^\||\|$/g, "").trim();
-  return inner.length > 0 && /^[-|: ]+$/.test(inner);
+  let s = line.trim();
+  if (s.startsWith("|")) s = s.slice(1);
+  if (s.endsWith("|")) s = s.slice(0, -1);
+  if (s.length === 0) return false;
+  return s.split("|").every((seg) => {
+    const trimmed = seg.trim().replace(/^:+|:+$/g, "");
+    return trimmed.length >= 3 && /^-+$/.test(trimmed);
+  });
 }
 
 /** Parse a table row into trimmed cells. */
@@ -187,7 +193,7 @@ function StateContent({ content }: { content: string }) {
       elements.push(
         <div
           key={elements.length}
-          className={`text-xs pl-3 ${statusClass(bulletText)}`}
+          className="text-xs pl-3 text-text-secondary"
         >
           &bull; {bulletText}
         </div>,
@@ -200,7 +206,7 @@ function StateContent({ content }: { content: string }) {
     elements.push(
       <p
         key={elements.length}
-        className={`text-xs ${statusClass(trimmed)}`}
+        className="text-xs text-text-secondary"
       >
         {trimmed}
       </p>,
@@ -216,12 +222,14 @@ export function StatePanel({ session, onClose }: Props) {
   const [loading, setLoading] = useState(true);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  const sessionId = session?.id ?? null;
+
   const poll = useCallback(async () => {
-    if (!session) return;
-    const md = await fetchStateMd(session.id);
+    if (!sessionId) return;
+    const md = await fetchStateMd(sessionId);
     setContent(md);
     setLoading(false);
-  }, [session]);
+  }, [sessionId]);
 
   useEffect(() => {
     setLoading(true);

--- a/web/src/components/StatePanel.tsx
+++ b/web/src/components/StatePanel.tsx
@@ -1,0 +1,270 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { SessionResponse } from "../lib/types";
+
+const POLL_INTERVAL_MS = 2500;
+
+interface Props {
+  session: SessionResponse | null;
+  onClose: () => void;
+}
+
+/** Fetch STATE.md content for a session via its project path. */
+async function fetchStateMd(sessionId: string): Promise<string | null> {
+  try {
+    const res = await fetch(`/api/sessions/${sessionId}/state`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.content ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Determine status color class from cell text. */
+function statusClass(text: string): string {
+  const lower = text.trim().toLowerCase();
+  if (
+    lower.includes("done") ||
+    lower.includes("completed") ||
+    lower.includes("\u2705")
+  )
+    return "text-status-running";
+  if (
+    lower.includes("implementing") ||
+    lower.includes("in_progress") ||
+    lower.includes("in-progress") ||
+    lower.includes("running") ||
+    lower.includes("\ud83d\udfe1")
+  )
+    return "text-status-waiting";
+  if (lower.includes("reviewing") || lower.includes("pending"))
+    return "text-brand-500";
+  if (
+    lower.includes("blocked") ||
+    lower.includes("failed") ||
+    lower.includes("\u274c")
+  )
+    return "text-status-error";
+  if (
+    lower.includes("not-started") ||
+    lower.includes("not_started") ||
+    lower.includes("skipped")
+  )
+    return "text-text-dim";
+  return "text-text-secondary";
+}
+
+/** Check if a table line is a separator row. */
+function isTableSeparator(line: string): boolean {
+  const inner = line.replace(/^\||\|$/g, "").trim();
+  return inner.length > 0 && /^[-|: ]+$/.test(inner);
+}
+
+/** Parse a table row into trimmed cells. */
+function parseTableRow(line: string): string[] {
+  let s = line.trim();
+  if (s.startsWith("|")) s = s.slice(1);
+  if (s.endsWith("|")) s = s.slice(0, -1);
+  return s.split("|").map((c) => c.trim());
+}
+
+/** Render a markdown table block as an HTML table. */
+function MarkdownTable({ lines }: { lines: string[] }) {
+  const dataLines = lines.filter((l) => !isTableSeparator(l));
+  if (dataLines.length === 0) return null;
+
+  const header = parseTableRow(dataLines[0]);
+  const rows = dataLines.slice(1).map(parseTableRow);
+
+  return (
+    <div className="overflow-x-auto my-1">
+      <table className="text-xs border-collapse w-full">
+        <thead>
+          <tr>
+            {header.map((cell, i) => (
+              <th
+                key={i}
+                className="text-left px-2 py-0.5 text-text-primary font-semibold border-b border-surface-700/30"
+              >
+                {cell}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, ri) => (
+            <tr
+              key={ri}
+              className="hover:bg-surface-800/30 transition-colors"
+            >
+              {row.map((cell, ci) => (
+                <td
+                  key={ci}
+                  className={`px-2 py-0.5 border-b border-surface-700/10 ${statusClass(cell)}`}
+                >
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Render STATE.md content as styled HTML. */
+function StateContent({ content }: { content: string }) {
+  const lines = content.split("\n");
+  const elements: React.ReactNode[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Collect table blocks
+    if (trimmed.startsWith("|") && (trimmed.match(/\|/g) ?? []).length >= 2) {
+      const tableLines: string[] = [];
+      while (
+        i < lines.length &&
+        lines[i].trim().startsWith("|") &&
+        (lines[i].trim().match(/\|/g) ?? []).length >= 2
+      ) {
+        tableLines.push(lines[i].trim());
+        i++;
+      }
+      elements.push(<MarkdownTable key={elements.length} lines={tableLines} />);
+      continue;
+    }
+
+    // Headers
+    if (trimmed.startsWith("### ")) {
+      elements.push(
+        <h4
+          key={elements.length}
+          className="text-xs font-semibold text-text-secondary mt-2 mb-0.5 italic"
+        >
+          {trimmed.slice(4)}
+        </h4>,
+      );
+      i++;
+      continue;
+    }
+    if (trimmed.startsWith("## ")) {
+      elements.push(
+        <h3
+          key={elements.length}
+          className="text-sm font-bold text-text-primary mt-3 mb-1"
+        >
+          {trimmed.slice(3)}
+        </h3>,
+      );
+      i++;
+      continue;
+    }
+    if (trimmed.startsWith("# ")) {
+      elements.push(
+        <h2
+          key={elements.length}
+          className="text-sm font-bold text-text-primary mt-2 mb-1"
+        >
+          {trimmed.slice(2)}
+        </h2>,
+      );
+      i++;
+      continue;
+    }
+
+    // Empty line
+    if (trimmed === "") {
+      elements.push(<div key={elements.length} className="h-1" />);
+      i++;
+      continue;
+    }
+
+    // Bullet points
+    if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
+      const bulletText = trimmed.slice(2);
+      elements.push(
+        <div
+          key={elements.length}
+          className={`text-xs pl-3 ${statusClass(bulletText)}`}
+        >
+          &bull; {bulletText}
+        </div>,
+      );
+      i++;
+      continue;
+    }
+
+    // Regular text
+    elements.push(
+      <p
+        key={elements.length}
+        className={`text-xs ${statusClass(trimmed)}`}
+      >
+        {trimmed}
+      </p>,
+    );
+    i++;
+  }
+
+  return <>{elements}</>;
+}
+
+export function StatePanel({ session, onClose }: Props) {
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const poll = useCallback(async () => {
+    if (!session) return;
+    const md = await fetchStateMd(session.id);
+    setContent(md);
+    setLoading(false);
+  }, [session]);
+
+  useEffect(() => {
+    setLoading(true);
+    setContent(null);
+    poll();
+    timerRef.current = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [poll]);
+
+  // No content = no panel (hide gracefully)
+  if (!loading && content === null) return null;
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 overflow-hidden border-l border-surface-700/20">
+      {/* Header */}
+      <div className="h-8 flex items-center px-3 border-b border-surface-700/20 shrink-0 bg-surface-900">
+        <span className="text-xs font-semibold text-brand-500 flex-1">
+          TPM State
+        </span>
+        <button
+          onClick={onClose}
+          className="w-6 h-6 flex items-center justify-center text-text-dim hover:text-text-secondary hover:bg-surface-800 cursor-pointer rounded transition-colors text-sm"
+        >
+          &times;
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-3 py-2">
+        {loading ? (
+          <span className="text-xs text-text-dim">Loading...</span>
+        ) : content ? (
+          <StateContent content={content} />
+        ) : (
+          <span className="text-xs text-text-dim">
+            No STATE.md found for this session.
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/StatePanel.tsx
+++ b/web/src/components/StatePanel.tsx
@@ -73,7 +73,7 @@ function MarkdownTable({ lines }: { lines: string[] }) {
   const dataLines = lines.filter((l) => !isTableSeparator(l));
   if (dataLines.length === 0) return null;
 
-  const header = parseTableRow(dataLines[0]);
+  const header = parseTableRow(dataLines[0]!);
   const rows = dataLines.slice(1).map(parseTableRow);
 
   return (
@@ -120,18 +120,16 @@ function StateContent({ content }: { content: string }) {
   let i = 0;
 
   while (i < lines.length) {
-    const line = lines[i];
+    const line = lines[i]!;
     const trimmed = line.trim();
 
     // Collect table blocks
     if (trimmed.startsWith("|") && (trimmed.match(/\|/g) ?? []).length >= 2) {
       const tableLines: string[] = [];
-      while (
-        i < lines.length &&
-        lines[i].trim().startsWith("|") &&
-        (lines[i].trim().match(/\|/g) ?? []).length >= 2
-      ) {
-        tableLines.push(lines[i].trim());
+      while (i < lines.length) {
+        const cur = lines[i]!.trim();
+        if (!cur.startsWith("|") || (cur.match(/\|/g) ?? []).length < 2) break;
+        tableLines.push(cur);
         i++;
       }
       elements.push(<MarkdownTable key={elements.length} lines={tableLines} />);

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -18,6 +18,8 @@ interface Props {
   loginRequired: boolean;
   isOffline: boolean;
   onGoDashboard: () => void;
+  onToggleStatePanel?: () => void;
+  statePanelOpen?: boolean;
 }
 
 export function TopBar({
@@ -35,6 +37,8 @@ export function TopBar({
   loginRequired,
   isOffline,
   onGoDashboard,
+  onToggleStatePanel,
+  statePanelOpen,
 }: Props) {
   const repoName =
     activeWorkspace?.projectPath.split("/").filter(Boolean).pop() ?? null;
@@ -123,6 +127,36 @@ export function TopBar({
             <span className="w-1.5 h-1.5 rounded-full bg-status-error animate-pulse" />
             offline
           </span>
+        )}
+
+        {activeWorkspace && activeSession && onToggleStatePanel && (
+          <button
+            onClick={onToggleStatePanel}
+            className={`w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors hover:bg-surface-700/50 ${
+              statePanelOpen
+                ? "text-brand-500 hover:text-brand-400"
+                : "text-text-dim hover:text-text-secondary"
+            }`}
+            title="Toggle TPM state panel (S)"
+            aria-label="Toggle TPM state panel"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <line x1="9" y1="3" x2="9" y2="21" />
+              <line x1="13" y1="8" x2="19" y2="8" />
+              <line x1="13" y1="12" x2="19" y2="12" />
+              <line x1="13" y1="16" x2="17" y2="16" />
+            </svg>
+          </button>
         )}
 
         {activeWorkspace && activeSession && (

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -7,6 +7,7 @@ interface ShortcutActions {
   onHelp: () => void;
   onSettings: () => void;
   onPalette: () => void;
+  onToggleState?: () => void;
 }
 
 /**
@@ -58,6 +59,10 @@ export function useKeyboardShortcuts(getActions: () => ShortcutActions) {
         case "s":
           e.preventDefault();
           actions.onSettings();
+          break;
+        case "S":
+          e.preventDefault();
+          actions.onToggleState?.();
           break;
       }
     };


### PR DESCRIPTION
## Summary

Implements the four remaining open issues in a single integration branch, orchestrated by the TPM workflow (prod tier, 5-layer adversarial review per task).

- **#8 Planner brainstorming skill**: new `skills/brainstorming/SKILL.md` with 4-phase structured ideation. Planner is now tier-aware: standard/prod invoke brainstorming + user confirmation before decomposing; fast skips both.
- **#9 STATE.md side panel**: toggleable TUI panel (`S` key) rendering `.tpm/STATE.md` with colored status badges, markdown tables, text wrapping, and J/K scrolling. Web dashboard gets a collapsible panel with the same content. Auto-refreshes every 2s.
- **#10 Auto-delete sessions**: orchestrator Step 6b now removes implementer AoE sessions after merge (worktrees kept for audit). `(deleted)` marker in STATE.md prevents reconciliation loop false positives.
- **#12 Ship agent**: new `agents/ship.md` for automated release workflows. Discovers repo conventions (CI/CD, tags, manifests, CHANGELOG), builds a skippable checklist, confirms with user, executes with partial-failure handling. Supports both `gh` and `glab`. Orchestrator gains opt-in Step 10b.

### Infrastructure fixes (included)

- `send_keys` rewritten to use `tmux load-buffer + paste-buffer` for reliable multiline message delivery
- Reviews dispatch as dedicated AoE sessions (not Agent subagents that block the orchestrator)
- Reconciliation loop `--format json` flag fixed to `--json`
- Review cycle limits enforced per tier: fast=1, standard=3, prod=10

### Review cycles

| Task | Cycles | Final verdict |
|---|---|---|
| task-01 planner-brainstorming | 2 | APPROVED |
| task-02 state-panel | 3 | APPROVED |
| task-03 auto-delete | 2 | APPROVED |
| task-04 ship-agent | 2 | APPROVED |

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy` clean
- [x] `cargo test`: 1117 passed, 2 pre-existing failures (unrelated)
- [x] TUI: S key toggles STATE.md panel on TPM sessions, no-op on regular sessions
- [x] TUI: J/K scroll, text wrapping, table color coding, keyboard hints
- [x] Manual validation by user on live TUI

Closes #8, #9, #10, #12
