### PR TITLE
feat(tpm): TPM indicator, config panel, and archival (#15, #16, #17)

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -91,14 +91,14 @@ pub struct AddArgs {
 
     /// Maximum number of review/revision cycles for the TPM orchestrator.
     /// 0 or omitted means use the tier default. Requires `--tpm`.
-    #[arg(long, value_name = "N")]
+    #[arg(long, value_name = "N", requires = "tpm")]
     tpm_review_passes: Option<u32>,
 
     /// Disable a TPM agent by slug. Can be repeated. The implementer agent
     /// cannot be disabled.
     ///
     /// Example: `--tpm-disable-agent principal-engineer --tpm-disable-agent end-user-simulator`
-    #[arg(long = "tpm-disable-agent", value_name = "AGENT", action = clap::ArgAction::Append)]
+    #[arg(long = "tpm-disable-agent", value_name = "AGENT", action = clap::ArgAction::Append, requires = "tpm")]
     tpm_disabled_agents: Vec<String>,
 }
 
@@ -340,14 +340,12 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         )?;
         instance.tpm_managed = true;
 
-        // Filter out "implementer" from disabled agents (always enabled)
         let disabled: Vec<String> = args
             .tpm_disabled_agents
             .iter()
             .filter(|a| a.as_str() != "implementer")
             .cloned()
             .collect();
-
         let tpm_config = crate::tpm::TpmConfig {
             tier,
             max_review_cycles: args.tpm_review_passes.filter(|&n| n > 0),

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -88,6 +88,18 @@ pub struct AddArgs {
     /// `--tpm=fast` or `--tpm=prod` selects a different tier.
     #[arg(long, num_args = 0..=1, default_missing_value = "standard", value_parser = clap::value_parser!(TpmTier))]
     tpm: Option<TpmTier>,
+
+    /// Maximum number of review/revision cycles for the TPM orchestrator.
+    /// 0 or omitted means use the tier default. Requires `--tpm`.
+    #[arg(long, value_name = "N")]
+    tpm_review_passes: Option<u32>,
+
+    /// Disable a TPM agent by slug. Can be repeated. The implementer agent
+    /// cannot be disabled.
+    ///
+    /// Example: `--tpm-disable-agent principal-engineer --tpm-disable-agent end-user-simulator`
+    #[arg(long = "tpm-disable-agent", value_name = "AGENT", action = clap::ArgAction::Append)]
+    tpm_disabled_agents: Vec<String>,
 }
 
 pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
@@ -326,6 +338,22 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             &instance.extra_args,
             tier,
         )?;
+        instance.tpm_managed = true;
+
+        // Filter out "implementer" from disabled agents (always enabled)
+        let disabled: Vec<String> = args
+            .tpm_disabled_agents
+            .iter()
+            .filter(|a| a.as_str() != "implementer")
+            .cloned()
+            .collect();
+
+        let tpm_config = crate::tpm::TpmConfig {
+            tier,
+            max_review_cycles: args.tpm_review_passes.filter(|&n| n > 0),
+            disabled_agents: disabled,
+        };
+        crate::tpm::write_tpm_config(&path, &tpm_config)?;
     }
 
     // Handle sandbox setup

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -113,6 +113,11 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
                 }
             }
 
+            // Archive .tpm/ artifacts before worktree cleanup destroys them.
+            if let Err(e) = crate::tpm::archive_tpm_artifacts(&inst) {
+                eprintln!("Warning: failed to archive TPM artifacts: {}", e);
+            }
+
             let will_cleanup_worktree = needs_worktree_cleanup(&inst, &args);
             // Delete branch if explicitly requested, or if worktree is being
             // deleted and config says to also delete the branch.

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -12,13 +12,14 @@ mod v001_xdg_linux;
 mod v002_seed_sandbox_from_volumes;
 mod v003_yolo_mode_config;
 mod v004_unified_environment;
+mod v005_tpm_managed_field;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 4;
+const CURRENT_VERSION: u32 = 5;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -47,6 +48,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 4,
         name: "unified_environment",
         run: v004_unified_environment::run,
+    },
+    Migration {
+        version: 5,
+        name: "tpm_managed_field",
+        run: v005_tpm_managed_field::run,
     },
 ];
 

--- a/src/migrations/v005_tpm_managed_field.rs
+++ b/src/migrations/v005_tpm_managed_field.rs
@@ -1,0 +1,215 @@
+//! Migration v005: Backfill `tpm_managed` field on existing sessions
+//!
+//! Sessions created with TPM orchestrator mode have `extra_args` containing
+//! `--append-system-prompt` and `TPM ORCHESTRATOR MODE`. This migration scans
+//! all profile session files and sets `tpm_managed: true` on matching instances
+//! so the TUI can display the TPM badge without parsing extra_args at render time.
+
+use anyhow::Result;
+use std::fs;
+use tracing::{debug, info};
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    let profiles_dir = app_dir.join("profiles");
+
+    if !profiles_dir.exists() {
+        debug!("No profiles directory, skipping tpm_managed migration");
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(&profiles_dir)? {
+        let entry = entry?;
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let sessions_path = entry.path().join("sessions.json");
+        migrate_sessions_file(&sessions_path)?;
+    }
+
+    Ok(())
+}
+
+fn migrate_sessions_file(path: &std::path::Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(path)?;
+    if content.trim().is_empty() {
+        return Ok(());
+    }
+
+    let mut sessions: Vec<serde_json::Value> = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            debug!("Failed to parse {}: {}, skipping", path.display(), e);
+            return Ok(());
+        }
+    };
+
+    let mut changed = false;
+    for session in &mut sessions {
+        let obj = match session.as_object_mut() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        // Skip if already set to true
+        if obj
+            .get("tpm_managed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        let extra_args = obj.get("extra_args").and_then(|v| v.as_str()).unwrap_or("");
+
+        if extra_args.contains("--append-system-prompt")
+            && extra_args.contains("TPM ORCHESTRATOR MODE")
+        {
+            obj.insert("tpm_managed".to_string(), serde_json::Value::Bool(true));
+            let title = obj
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("<unknown>");
+            info!("Marked session '{}' as tpm_managed", title);
+            changed = true;
+        }
+    }
+
+    if changed {
+        let new_content = serde_json::to_string_pretty(&sessions)?;
+        fs::write(path, new_content)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_migrate_sets_tpm_managed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sessions_path = dir.path().join("sessions.json");
+
+        let content = serde_json::json!([
+            {
+                "id": "abc123",
+                "title": "orchestrator",
+                "project_path": "/tmp/test",
+                "extra_args": "--append-system-prompt 'TPM ORCHESTRATOR MODE tier=fast'",
+                "tool": "claude",
+                "status": "idle",
+                "created_at": "2025-01-01T00:00:00Z"
+            },
+            {
+                "id": "def456",
+                "title": "regular",
+                "project_path": "/tmp/test2",
+                "extra_args": "",
+                "tool": "claude",
+                "status": "idle",
+                "created_at": "2025-01-01T00:00:00Z"
+            }
+        ]);
+        fs::write(
+            &sessions_path,
+            serde_json::to_string_pretty(&content).unwrap(),
+        )
+        .unwrap();
+
+        migrate_sessions_file(&sessions_path).unwrap();
+
+        let result: Vec<serde_json::Value> =
+            serde_json::from_str(&fs::read_to_string(&sessions_path).unwrap()).unwrap();
+
+        assert_eq!(
+            result[0]["tpm_managed"].as_bool(),
+            Some(true),
+            "TPM session should be marked as tpm_managed"
+        );
+        assert!(
+            result[1].get("tpm_managed").is_none()
+                || result[1]["tpm_managed"].as_bool() == Some(false),
+            "Regular session should not be marked as tpm_managed"
+        );
+    }
+
+    #[test]
+    fn test_migrate_idempotent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sessions_path = dir.path().join("sessions.json");
+
+        let content = serde_json::json!([{
+            "id": "abc123",
+            "title": "orchestrator",
+            "project_path": "/tmp/test",
+            "extra_args": "--append-system-prompt 'TPM ORCHESTRATOR MODE tier=fast'",
+            "tpm_managed": true,
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2025-01-01T00:00:00Z"
+        }]);
+        fs::write(
+            &sessions_path,
+            serde_json::to_string_pretty(&content).unwrap(),
+        )
+        .unwrap();
+
+        migrate_sessions_file(&sessions_path).unwrap();
+
+        let result: Vec<serde_json::Value> =
+            serde_json::from_str(&fs::read_to_string(&sessions_path).unwrap()).unwrap();
+
+        assert_eq!(result[0]["tpm_managed"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn test_migrate_nonexistent_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sessions_path = dir.path().join("nonexistent.json");
+        migrate_sessions_file(&sessions_path).unwrap();
+    }
+
+    #[test]
+    fn test_migrate_empty_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sessions_path = dir.path().join("sessions.json");
+        fs::write(&sessions_path, "").unwrap();
+        migrate_sessions_file(&sessions_path).unwrap();
+    }
+
+    #[test]
+    fn test_migrate_no_matching_sessions() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sessions_path = dir.path().join("sessions.json");
+
+        let content = serde_json::json!([{
+            "id": "abc123",
+            "title": "regular",
+            "project_path": "/tmp/test",
+            "extra_args": "--model opus",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2025-01-01T00:00:00Z"
+        }]);
+        fs::write(
+            &sessions_path,
+            serde_json::to_string_pretty(&content).unwrap(),
+        )
+        .unwrap();
+
+        let before = fs::read_to_string(&sessions_path).unwrap();
+        migrate_sessions_file(&sessions_path).unwrap();
+        let after = fs::read_to_string(&sessions_path).unwrap();
+
+        assert_eq!(
+            before, after,
+            "File should not be modified when no sessions match"
+        );
+    }
+}

--- a/src/migrations/v005_tpm_managed_field.rs
+++ b/src/migrations/v005_tpm_managed_field.rs
@@ -18,13 +18,37 @@ pub fn run() -> Result<()> {
         return Ok(());
     }
 
-    for entry in fs::read_dir(&profiles_dir)? {
-        let entry = entry?;
+    let entries = match fs::read_dir(&profiles_dir) {
+        Ok(e) => e,
+        Err(e) => {
+            debug!(
+                "Cannot read profiles directory {}: {}, skipping",
+                profiles_dir.display(),
+                e
+            );
+            return Ok(());
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                debug!("Failed to read profile entry: {}, skipping", e);
+                continue;
+            }
+        };
         if !entry.path().is_dir() {
             continue;
         }
         let sessions_path = entry.path().join("sessions.json");
-        migrate_sessions_file(&sessions_path)?;
+        if let Err(e) = migrate_sessions_file(&sessions_path) {
+            debug!(
+                "Failed to migrate {}: {}, skipping",
+                sessions_path.display(),
+                e
+            );
+        }
     }
 
     Ok(())
@@ -35,7 +59,13 @@ fn migrate_sessions_file(path: &std::path::Path) -> Result<()> {
         return Ok(());
     }
 
-    let content = fs::read_to_string(path)?;
+    let content = match fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            debug!("Failed to read {}: {}, skipping", path.display(), e);
+            return Ok(());
+        }
+    };
     if content.trim().is_empty() {
         return Ok(());
     }

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -279,6 +279,8 @@ pub async fn create_session(
             // The web dashboard does not yet expose TPM tier selection;
             // `None` preserves the previous behavior (no orchestrator prompt).
             tpm_tier: None,
+            tpm_review_passes: None,
+            tpm_disabled_agents: Vec::new(),
             // No equivalent in the web API today — defaults to HEAD.
             worktree_from_branch: None,
         };

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -489,6 +489,90 @@ fn resolve_title(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_build_instance_sets_tpm_managed_when_tier_present() {
+        let temp = tempfile::TempDir::new().unwrap();
+        // Isolate HOME so config resolution uses temp dirs
+        std::env::set_var("HOME", temp.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+        // Set up a fake orchestrator prompt so build_tpm_extra_args resolves
+        let tpm_dir = temp.path().join("tpm-plugin");
+        let agents_dir = tpm_dir.join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(agents_dir.join("orchestrator.md"), "# Orchestrator\n").unwrap();
+        std::env::set_var("TPM_WORKFLOW_PATH", &tpm_dir);
+
+        // Create project directory
+        let project_dir = temp.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let params = InstanceParams {
+            title: "tpm-test".to_string(),
+            path: project_dir.to_string_lossy().to_string(),
+            group: String::new(),
+            tool: "claude".to_string(),
+            worktree_branch: None,
+            create_new_branch: false,
+            worktree_from_branch: None,
+            sandbox: false,
+            sandbox_image: String::new(),
+            yolo_mode: false,
+            extra_env: Vec::new(),
+            extra_args: String::new(),
+            command_override: String::new(),
+            extra_repo_paths: Vec::new(),
+            tpm_tier: Some(crate::tpm::TpmTier::Fast),
+        };
+
+        let result = build_instance(params, &[], "default").unwrap();
+        assert!(
+            result.instance.tpm_managed,
+            "tpm_managed should be true when tpm_tier is Some"
+        );
+
+        std::env::remove_var("TPM_WORKFLOW_PATH");
+    }
+
+    #[test]
+    #[serial]
+    fn test_build_instance_tpm_managed_false_without_tier() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+        let project_dir = temp.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let params = InstanceParams {
+            title: "regular-test".to_string(),
+            path: project_dir.to_string_lossy().to_string(),
+            group: String::new(),
+            tool: "claude".to_string(),
+            worktree_branch: None,
+            create_new_branch: false,
+            worktree_from_branch: None,
+            sandbox: false,
+            sandbox_image: String::new(),
+            yolo_mode: false,
+            extra_env: Vec::new(),
+            extra_args: String::new(),
+            command_override: String::new(),
+            extra_repo_paths: Vec::new(),
+            tpm_tier: None,
+        };
+
+        let result = build_instance(params, &[], "default").unwrap();
+        assert!(
+            !result.instance.tpm_managed,
+            "tpm_managed should be false when tpm_tier is None"
+        );
+    }
 
     #[test]
     fn test_empty_title_with_worktree_uses_branch_name() {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -396,6 +396,7 @@ pub fn build_instance(
             &instance.extra_args,
             tier,
         )?;
+        instance.tpm_managed = true;
     }
 
     if params.sandbox {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -415,9 +415,7 @@ pub fn build_instance(
             disabled_agents: disabled,
         };
         let project_path = std::path::Path::new(&instance.project_path);
-        if let Err(e) = crate::tpm::write_tpm_config(project_path, &tpm_config) {
-            tracing::warn!("failed to write TPM config: {}", e);
-        }
+        crate::tpm::write_tpm_config(project_path, &tpm_config)?;
     }
 
     if params.sandbox {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -48,6 +48,10 @@ pub struct InstanceParams {
     /// See `crate::tpm` for resolution rules and the shell snippet that gets
     /// merged in.
     pub tpm_tier: Option<crate::tpm::TpmTier>,
+    /// Maximum review/revision cycles for the TPM orchestrator.
+    pub tpm_review_passes: Option<u32>,
+    /// Agent slugs to disable for this TPM session.
+    pub tpm_disabled_agents: Vec<String>,
 }
 
 /// Result of building an instance, tracking what was created for cleanup purposes.
@@ -397,6 +401,23 @@ pub fn build_instance(
             tier,
         )?;
         instance.tpm_managed = true;
+
+        // Write TPM config to .tpm/config.json so the orchestrator can read it.
+        let disabled: Vec<String> = params
+            .tpm_disabled_agents
+            .iter()
+            .filter(|a| a.as_str() != "implementer")
+            .cloned()
+            .collect();
+        let tpm_config = crate::tpm::TpmConfig {
+            tier,
+            max_review_cycles: params.tpm_review_passes.filter(|&n| n > 0),
+            disabled_agents: disabled,
+        };
+        let project_path = std::path::Path::new(&instance.project_path);
+        if let Err(e) = crate::tpm::write_tpm_config(project_path, &tpm_config) {
+            tracing::warn!("failed to write TPM config: {}", e);
+        }
     }
 
     if params.sandbox {
@@ -527,6 +548,8 @@ mod tests {
             command_override: String::new(),
             extra_repo_paths: Vec::new(),
             tpm_tier: Some(crate::tpm::TpmTier::Fast),
+            tpm_review_passes: None,
+            tpm_disabled_agents: Vec::new(),
         };
 
         let result = build_instance(params, &[], "default").unwrap();
@@ -565,6 +588,8 @@ mod tests {
             command_override: String::new(),
             extra_repo_paths: Vec::new(),
             tpm_tier: None,
+            tpm_review_passes: None,
+            tpm_disabled_agents: Vec::new(),
         };
 
         let result = build_instance(params, &[], "default").unwrap();

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -44,6 +44,9 @@ pub struct Config {
     pub sound: crate::sound::SoundConfig,
 
     #[serde(default)]
+    pub tpm: crate::tpm::TpmConfig,
+
+    #[serde(default)]
     pub app_state: AppStateConfig,
 
     #[serde(default)]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -129,6 +129,10 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub terminal_info: Option<TerminalInfo>,
 
+    /// Whether this session is managed by the TPM workflow (created with a tpm_tier).
+    #[serde(default)]
+    pub tpm_managed: bool,
+
     /// Runtime-only: which profile this instance was loaded from. Not persisted to disk.
     #[serde(default, skip_serializing)]
     pub source_profile: String,
@@ -162,6 +166,7 @@ impl Instance {
             workspace_info: None,
             sandbox_info: None,
             terminal_info: None,
+            tpm_managed: false,
             source_profile: String::new(),
             last_error_check: None,
             last_start_time: None,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -29,8 +29,8 @@ pub use profile_config::{
     load_profile_config, merge_configs, resolve_config, save_profile_config,
     validate_check_interval, validate_memory_limit, validate_path_exists, validate_volume_format,
     ClaudeConfigOverride, HooksConfigOverride, ProfileConfig, SandboxConfigOverride,
-    SessionConfigOverride, ThemeConfigOverride, TmuxConfigOverride, UpdatesConfigOverride,
-    WorktreeConfigOverride,
+    SessionConfigOverride, ThemeConfigOverride, TmuxConfigOverride, TpmConfigOverride,
+    UpdatesConfigOverride, WorktreeConfigOverride,
 };
 pub use repo_config::{
     check_hook_trust, execute_hooks, execute_hooks_in_container, load_repo_config,

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -828,6 +828,180 @@ mod tests {
         assert_eq!(merged.theme.name, "catppuccin-latte");
     }
 
+    // --- TPM config override tests ---
+
+    #[test]
+    fn test_merge_configs_tpm_tier_override() {
+        let mut global = Config::default();
+        global.tpm.tier = crate::tpm::TpmTier::Standard;
+
+        let profile = ProfileConfig {
+            tpm: Some(TpmConfigOverride {
+                tier: Some(crate::tpm::TpmTier::Prod),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let merged = merge_configs(global, &profile);
+        assert_eq!(merged.tpm.tier, crate::tpm::TpmTier::Prod);
+    }
+
+    #[test]
+    fn test_merge_configs_tpm_inherits_when_not_overridden() {
+        let mut global = Config::default();
+        global.tpm.tier = crate::tpm::TpmTier::Fast;
+        global.tpm.max_review_cycles = Some(7);
+        global.tpm.disabled_agents = vec!["principal-engineer".to_string()];
+
+        let profile = ProfileConfig::default();
+        let merged = merge_configs(global, &profile);
+
+        assert_eq!(merged.tpm.tier, crate::tpm::TpmTier::Fast);
+        assert_eq!(merged.tpm.max_review_cycles, Some(7));
+        assert_eq!(merged.tpm.disabled_agents, vec!["principal-engineer"]);
+    }
+
+    #[test]
+    fn test_merge_configs_tpm_max_review_cycles_override() {
+        let mut global = Config::default();
+        global.tpm.max_review_cycles = Some(10);
+
+        let profile = ProfileConfig {
+            tpm: Some(TpmConfigOverride {
+                max_review_cycles: Some(Some(3)),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let merged = merge_configs(global, &profile);
+        assert_eq!(merged.tpm.max_review_cycles, Some(3));
+    }
+
+    #[test]
+    fn test_merge_configs_tpm_max_review_cycles_clear_override() {
+        let mut global = Config::default();
+        global.tpm.max_review_cycles = Some(10);
+
+        // Some(None) means "explicitly clear the override back to tier default"
+        let profile = ProfileConfig {
+            tpm: Some(TpmConfigOverride {
+                max_review_cycles: Some(None),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let merged = merge_configs(global, &profile);
+        assert!(
+            merged.tpm.max_review_cycles.is_none(),
+            "Some(None) override should clear max_review_cycles"
+        );
+    }
+
+    #[test]
+    fn test_merge_configs_tpm_disabled_agents_override() {
+        let mut global = Config::default();
+        global.tpm.disabled_agents = vec!["principal-engineer".to_string()];
+
+        let profile = ProfileConfig {
+            tpm: Some(TpmConfigOverride {
+                disabled_agents: Some(vec![
+                    "end-user-simulator".to_string(),
+                    "blind-hunter".to_string(),
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let merged = merge_configs(global, &profile);
+        assert_eq!(
+            merged.tpm.disabled_agents,
+            vec!["end-user-simulator", "blind-hunter"],
+            "profile override should replace, not append"
+        );
+    }
+
+    #[test]
+    fn test_merge_configs_tpm_partial_override_preserves_others() {
+        let mut global = Config::default();
+        global.tpm.tier = crate::tpm::TpmTier::Fast;
+        global.tpm.max_review_cycles = Some(2);
+        global.tpm.disabled_agents = vec!["blind-hunter".to_string()];
+
+        // Only override tier; max_review_cycles and disabled_agents should survive
+        let profile = ProfileConfig {
+            tpm: Some(TpmConfigOverride {
+                tier: Some(crate::tpm::TpmTier::Prod),
+                max_review_cycles: None,
+                disabled_agents: None,
+            }),
+            ..Default::default()
+        };
+
+        let merged = merge_configs(global, &profile);
+        assert_eq!(merged.tpm.tier, crate::tpm::TpmTier::Prod);
+        assert_eq!(merged.tpm.max_review_cycles, Some(2));
+        assert_eq!(merged.tpm.disabled_agents, vec!["blind-hunter"]);
+    }
+
+    #[test]
+    fn test_tpm_config_override_toml_roundtrip() {
+        let config = ProfileConfig {
+            tpm: Some(TpmConfigOverride {
+                tier: Some(crate::tpm::TpmTier::Prod),
+                max_review_cycles: Some(Some(5)),
+                disabled_agents: Some(vec!["end-user-simulator".to_string()]),
+            }),
+            ..Default::default()
+        };
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        assert!(serialized.contains("[tpm]"));
+        assert!(serialized.contains("prod"));
+
+        let deserialized: ProfileConfig = toml::from_str(&serialized).unwrap();
+        let tpm = deserialized.tpm.unwrap();
+        assert_eq!(tpm.tier, Some(crate::tpm::TpmTier::Prod));
+        assert_eq!(tpm.max_review_cycles, Some(Some(5)));
+        assert_eq!(
+            tpm.disabled_agents,
+            Some(vec!["end-user-simulator".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_tpm_config_override_empty_toml_roundtrip() {
+        let config = ProfileConfig {
+            tpm: Some(TpmConfigOverride::default()),
+            ..Default::default()
+        };
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let deserialized: ProfileConfig = toml::from_str(&serialized).unwrap();
+        // Empty TpmConfigOverride may serialize as [tpm] section or be omitted;
+        // either way deserializing back should give us the default.
+        if let Some(tpm) = deserialized.tpm {
+            assert!(tpm.tier.is_none());
+            assert!(tpm.max_review_cycles.is_none());
+            assert!(tpm.disabled_agents.is_none());
+        }
+    }
+
+    #[test]
+    fn test_profile_has_overrides_with_tpm() {
+        let with_tpm = ProfileConfig {
+            tpm: Some(TpmConfigOverride {
+                tier: Some(crate::tpm::TpmTier::Fast),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(profile_has_overrides(&with_tpm));
+    }
+
     #[test]
     fn test_sandbox_override_string_shorthand() {
         // Regression test: all Option<Vec<String>> sandbox fields accept a plain string

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -42,6 +42,9 @@ pub struct ProfileConfig {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sound: Option<crate::sound::SoundConfigOverride>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tpm: Option<TpmConfigOverride>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -210,6 +213,16 @@ pub struct HooksConfigOverride {
     pub on_destroy: Option<Vec<String>>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TpmConfigOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tier: Option<crate::tpm::TpmTier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_review_cycles: Option<Option<u32>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled_agents: Option<Vec<String>>,
+}
+
 /// Load profile-specific config. Returns empty config if file doesn't exist.
 pub fn load_profile_config(profile: &str) -> Result<ProfileConfig> {
     let path = get_profile_config_path(profile)?;
@@ -248,6 +261,7 @@ pub fn profile_has_overrides(config: &ProfileConfig) -> bool {
         || config.session.is_some()
         || config.hooks.is_some()
         || config.sound.is_some()
+        || config.tpm.is_some()
 }
 
 /// Load effective config for a profile (global + profile overrides merged)
@@ -385,6 +399,19 @@ pub fn apply_tmux_overrides(target: &mut super::config::TmuxConfig, source: &Tmu
     }
 }
 
+/// Apply TPM config overrides to a target config.
+pub fn apply_tpm_overrides(target: &mut crate::tpm::TpmConfig, source: &TpmConfigOverride) {
+    if let Some(tier) = source.tier {
+        target.tier = tier;
+    }
+    if let Some(ref max_review_cycles) = source.max_review_cycles {
+        target.max_review_cycles = *max_review_cycles;
+    }
+    if let Some(ref disabled_agents) = source.disabled_agents {
+        target.disabled_agents = disabled_agents.clone();
+    }
+}
+
 /// Merge profile overrides into global config
 pub fn merge_configs(mut global: Config, profile: &ProfileConfig) -> Config {
     if let Some(ref theme_override) = profile.theme {
@@ -436,6 +463,10 @@ pub fn merge_configs(mut global: Config, profile: &ProfileConfig) -> Config {
 
     if let Some(ref sound_override) = profile.sound {
         crate::sound::apply_sound_overrides(&mut global.sound, sound_override);
+    }
+
+    if let Some(ref tpm_override) = profile.tpm {
+        apply_tpm_overrides(&mut global.tpm, tpm_override);
     }
 
     global

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -23,6 +23,8 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
 
+use crate::session::Instance;
+
 /// Tier of TPM orchestration. Controls how the orchestrator dispatches work.
 /// Currently threaded through the call chain without behavioral effect; future
 /// waves will use it to select different orchestration strategies.
@@ -607,6 +609,110 @@ pub fn build_tpm_extra_args(
     ))
 }
 
+/// TPM artifact filenames eligible for archival.
+const ARCHIVABLE_FILES: &[&str] = &["STATE.md", "SUMMARY.md", "PLAN.md", "config.json"];
+
+/// Resolve the `.tpm/` directory for a session instance.
+///
+/// Checks worktree main_repo_path first (the primary repo root for worktree
+/// sessions), then falls back to project_path (for non-worktree sessions or
+/// when the main repo doesn't have `.tpm/`). For workspace sessions, checks
+/// the first repo's worktree_path as a last resort.
+///
+/// Returns `None` if no `.tpm/` directory with a `STATE.md` exists.
+pub fn resolve_tpm_dir(instance: &Instance) -> Option<PathBuf> {
+    // Worktree session: check main_repo_path first
+    if let Some(wt) = &instance.worktree_info {
+        let candidate = PathBuf::from(&wt.main_repo_path).join(".tpm");
+        if candidate.join("STATE.md").is_file() {
+            return Some(candidate);
+        }
+    }
+
+    // project_path (always present)
+    let candidate = PathBuf::from(&instance.project_path).join(".tpm");
+    if candidate.join("STATE.md").is_file() {
+        return Some(candidate);
+    }
+
+    // Workspace session: check first repo's worktree_path
+    if let Some(ws) = &instance.workspace_info {
+        if let Some(repo) = ws.repos.first() {
+            let candidate = PathBuf::from(&repo.worktree_path).join(".tpm");
+            if candidate.join("STATE.md").is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
+/// Replace characters unsafe for filenames with hyphens.
+fn sanitize_title(title: &str) -> String {
+    title
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Archive `.tpm/` artifacts to the AoE history directory before worktree
+/// cleanup. Returns `Ok(true)` if archival happened, `Ok(false)` if no
+/// `.tpm/STATE.md` was found on disk. Errors are propagated but callers
+/// should treat them as non-fatal warnings.
+pub fn archive_tpm_artifacts(instance: &Instance) -> Result<bool> {
+    let tpm_dir = match resolve_tpm_dir(instance) {
+        Some(dir) => dir,
+        None => return Ok(false),
+    };
+
+    let app_dir = crate::session::get_app_dir().context("failed to locate AoE config dir")?;
+    let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+    let safe_title = sanitize_title(&instance.title);
+    let archive_dir = app_dir
+        .join("history")
+        .join(format!("{}_{}", timestamp, safe_title));
+
+    std::fs::create_dir_all(&archive_dir)
+        .with_context(|| format!("failed to create {}", archive_dir.display()))?;
+
+    for filename in ARCHIVABLE_FILES {
+        let src = tpm_dir.join(filename);
+        if src.is_file() {
+            let dest = archive_dir.join(filename);
+            std::fs::copy(&src, &dest).with_context(|| {
+                format!("failed to copy {} to {}", src.display(), dest.display())
+            })?;
+        }
+    }
+
+    // Write metadata.json with session context
+    let metadata = serde_json::json!({
+        "session_id": instance.id,
+        "title": instance.title,
+        "archived_at": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "project_path": instance.project_path,
+    });
+    let metadata_path = archive_dir.join("metadata.json");
+    let serialized = serde_json::to_string_pretty(&metadata)?;
+    std::fs::write(&metadata_path, serialized)
+        .with_context(|| format!("failed to write {}", metadata_path.display()))?;
+
+    tracing::info!(
+        "archived TPM artifacts for session {} to {}",
+        instance.id,
+        archive_dir.display()
+    );
+
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1116,5 +1222,148 @@ mod tests {
             "error missing substring: {}",
             err
         );
+    }
+
+    // --- archive / resolve_tpm_dir tests ---
+
+    fn create_test_instance(title: &str, project_path: &str) -> Instance {
+        Instance::new(title, project_path)
+    }
+
+    #[test]
+    fn sanitize_title_replaces_unsafe_chars() {
+        assert_eq!(sanitize_title("my-task"), "my-task");
+        assert_eq!(sanitize_title("feat/new thing"), "feat-new-thing");
+        assert_eq!(sanitize_title("hello world: test!"), "hello-world--test-");
+        assert_eq!(
+            sanitize_title("dots.and_underscores"),
+            "dots.and_underscores"
+        );
+    }
+
+    #[test]
+    fn sanitize_title_empty_string() {
+        assert_eq!(sanitize_title(""), "");
+    }
+
+    #[test]
+    fn resolve_tpm_dir_returns_none_when_no_tpm_dir() {
+        let dir = TempDir::new().unwrap();
+        let instance = create_test_instance("test", dir.path().to_str().unwrap());
+        assert!(resolve_tpm_dir(&instance).is_none());
+    }
+
+    #[test]
+    fn resolve_tpm_dir_finds_tpm_in_project_path() {
+        let dir = TempDir::new().unwrap();
+        let tpm = dir.path().join(".tpm");
+        std::fs::create_dir_all(&tpm).unwrap();
+        std::fs::write(tpm.join("STATE.md"), "# State\n").unwrap();
+
+        let instance = create_test_instance("test", dir.path().to_str().unwrap());
+        let resolved = resolve_tpm_dir(&instance);
+        assert_eq!(resolved, Some(tpm));
+    }
+
+    #[test]
+    fn resolve_tpm_dir_requires_state_md() {
+        let dir = TempDir::new().unwrap();
+        let tpm = dir.path().join(".tpm");
+        std::fs::create_dir_all(&tpm).unwrap();
+        // .tpm/ exists but no STATE.md inside
+        std::fs::write(tpm.join("PLAN.md"), "# Plan\n").unwrap();
+
+        let instance = create_test_instance("test", dir.path().to_str().unwrap());
+        assert!(resolve_tpm_dir(&instance).is_none());
+    }
+
+    #[test]
+    fn resolve_tpm_dir_prefers_main_repo_path() {
+        let main_repo = TempDir::new().unwrap();
+        let worktree = TempDir::new().unwrap();
+
+        // Put STATE.md in both locations
+        let main_tpm = main_repo.path().join(".tpm");
+        std::fs::create_dir_all(&main_tpm).unwrap();
+        std::fs::write(main_tpm.join("STATE.md"), "# Main\n").unwrap();
+
+        let wt_tpm = worktree.path().join(".tpm");
+        std::fs::create_dir_all(&wt_tpm).unwrap();
+        std::fs::write(wt_tpm.join("STATE.md"), "# WT\n").unwrap();
+
+        let mut instance = create_test_instance("test", worktree.path().to_str().unwrap());
+        instance.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "feature/test".to_string(),
+            main_repo_path: main_repo.path().to_string_lossy().to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+        });
+
+        let resolved = resolve_tpm_dir(&instance);
+        assert_eq!(resolved, Some(main_tpm));
+    }
+
+    #[test]
+    fn archive_tpm_artifacts_returns_false_when_no_tpm() {
+        let dir = TempDir::new().unwrap();
+        let instance = create_test_instance("test", dir.path().to_str().unwrap());
+        assert_eq!(archive_tpm_artifacts(&instance).unwrap(), false);
+    }
+
+    #[test]
+    fn archive_tpm_artifacts_copies_files_and_writes_metadata() {
+        let project = TempDir::new().unwrap();
+        let tpm = project.path().join(".tpm");
+        std::fs::create_dir_all(&tpm).unwrap();
+        std::fs::write(tpm.join("STATE.md"), "# State content\n").unwrap();
+        std::fs::write(tpm.join("SUMMARY.md"), "# Summary content\n").unwrap();
+        // PLAN.md absent, should be skipped gracefully
+
+        let instance = create_test_instance("my-task", project.path().to_str().unwrap());
+        let result = archive_tpm_artifacts(&instance).unwrap();
+        assert!(result, "archival should have happened");
+
+        // Find the archive directory
+        let app_dir = crate::session::get_app_dir().unwrap();
+        let history_dir = app_dir.join("history");
+        assert!(history_dir.exists(), "history dir should exist");
+
+        let entries: Vec<_> = std::fs::read_dir(&history_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(entries.len(), 1, "expected exactly one archive entry");
+
+        let archive_dir = entries[0].path();
+        let dir_name = archive_dir
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        assert!(
+            dir_name.ends_with("_my-task"),
+            "dir name should end with _my-task, got: {}",
+            dir_name
+        );
+
+        // Check copied files
+        assert!(archive_dir.join("STATE.md").is_file());
+        assert!(archive_dir.join("SUMMARY.md").is_file());
+        assert!(!archive_dir.join("PLAN.md").exists());
+
+        // Check content preserved
+        let state = std::fs::read_to_string(archive_dir.join("STATE.md")).unwrap();
+        assert_eq!(state, "# State content\n");
+
+        // Check metadata.json
+        let meta_str = std::fs::read_to_string(archive_dir.join("metadata.json")).unwrap();
+        let meta: serde_json::Value = serde_json::from_str(&meta_str).unwrap();
+        assert_eq!(meta["session_id"].as_str().unwrap(), instance.id);
+        assert_eq!(meta["title"].as_str().unwrap(), "my-task");
+        assert_eq!(
+            meta["project_path"].as_str().unwrap(),
+            project.path().to_str().unwrap()
+        );
+        assert!(meta["archived_at"].as_str().is_some());
     }
 }

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -22,18 +22,61 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
 
 use crate::session::Instance;
 
 /// Tier of TPM orchestration. Controls how the orchestrator dispatches work.
 /// Currently threaded through the call chain without behavioral effect; future
 /// waves will use it to select different orchestration strategies.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum TpmTier {
     Fast,
     #[default]
     Standard,
     Prod,
+}
+
+/// Known TPM agent slugs. The orchestrator dispatches these sub-sessions;
+/// the implementer is always enabled and cannot be disabled.
+pub const KNOWN_AGENTS: &[&str] = &[
+    "planner",
+    "implementer",
+    "adversarial-reviewer",
+    "blind-hunter",
+    "edge-case-hunter",
+    "acceptance-auditor",
+    "merge-resolver",
+    "qa-validator",
+    "principal-engineer",
+    "end-user-simulator",
+];
+
+/// TPM configuration that controls orchestrator behavior. Persisted to
+/// `.tpm/config.json` at session creation so the orchestrator can read it.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct TpmConfig {
+    #[serde(default)]
+    pub tier: TpmTier,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_review_cycles: Option<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disabled_agents: Vec<String>,
+}
+
+/// Write `TpmConfig` as JSON to `.tpm/config.json` in the given project root.
+/// Creates the `.tpm/` directory if it does not exist.
+pub fn write_tpm_config(project_root: &Path, config: &TpmConfig) -> Result<()> {
+    let tpm_dir = project_root.join(".tpm");
+    std::fs::create_dir_all(&tpm_dir)
+        .with_context(|| format!("failed to create {}", tpm_dir.display()))?;
+    let config_path = tpm_dir.join("config.json");
+    let serialized = serde_json::to_string_pretty(config)?;
+    std::fs::write(&config_path, serialized)
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+    tracing::info!("wrote TPM config to {}", config_path.display());
+    Ok(())
 }
 
 impl std::fmt::Display for TpmTier {

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -1452,6 +1452,148 @@ mod tests {
         assert_eq!(archive_tpm_artifacts(&instance).unwrap(), false);
     }
 
+    // --- TpmConfig serde tests ---
+
+    #[test]
+    fn tpm_config_default_values() {
+        let config = TpmConfig::default();
+        assert_eq!(config.tier, TpmTier::Standard);
+        assert!(config.max_review_cycles.is_none());
+        assert!(config.disabled_agents.is_empty());
+    }
+
+    #[test]
+    fn tpm_config_json_roundtrip_default() {
+        let config = TpmConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: TpmConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.tier, TpmTier::Standard);
+        assert!(parsed.max_review_cycles.is_none());
+        assert!(parsed.disabled_agents.is_empty());
+    }
+
+    #[test]
+    fn tpm_config_json_roundtrip_with_overrides() {
+        let config = TpmConfig {
+            tier: TpmTier::Prod,
+            max_review_cycles: Some(5),
+            disabled_agents: vec![
+                "principal-engineer".to_string(),
+                "end-user-simulator".to_string(),
+            ],
+        };
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        let parsed: TpmConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.tier, TpmTier::Prod);
+        assert_eq!(parsed.max_review_cycles, Some(5));
+        assert_eq!(parsed.disabled_agents.len(), 2);
+        assert_eq!(parsed.disabled_agents[0], "principal-engineer");
+        assert_eq!(parsed.disabled_agents[1], "end-user-simulator");
+    }
+
+    #[test]
+    fn tpm_config_json_roundtrip_with_disabled_agents_only() {
+        let config = TpmConfig {
+            tier: TpmTier::Fast,
+            max_review_cycles: None,
+            disabled_agents: vec!["blind-hunter".to_string()],
+        };
+        let json = serde_json::to_string(&config).unwrap();
+
+        // max_review_cycles should be absent from JSON (skip_serializing_if)
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            raw.get("max_review_cycles").is_none(),
+            "None max_review_cycles should be omitted from JSON"
+        );
+
+        let parsed: TpmConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.tier, TpmTier::Fast);
+        assert!(parsed.max_review_cycles.is_none());
+        assert_eq!(parsed.disabled_agents, vec!["blind-hunter"]);
+    }
+
+    #[test]
+    fn tpm_config_json_skips_empty_disabled_agents() {
+        let config = TpmConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            raw.get("disabled_agents").is_none(),
+            "empty disabled_agents should be omitted from JSON"
+        );
+    }
+
+    #[test]
+    fn tpm_tier_json_serde_roundtrip() {
+        for tier in [TpmTier::Fast, TpmTier::Standard, TpmTier::Prod] {
+            let json = serde_json::to_string(&tier).unwrap();
+            let parsed: TpmTier = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, tier, "JSON roundtrip failed for {:?}", tier);
+        }
+    }
+
+    #[test]
+    fn tpm_tier_json_serializes_lowercase() {
+        assert_eq!(serde_json::to_string(&TpmTier::Fast).unwrap(), "\"fast\"");
+        assert_eq!(
+            serde_json::to_string(&TpmTier::Standard).unwrap(),
+            "\"standard\""
+        );
+        assert_eq!(serde_json::to_string(&TpmTier::Prod).unwrap(), "\"prod\"");
+    }
+
+    #[test]
+    fn write_tpm_config_creates_correct_json() {
+        let dir = TempDir::new().unwrap();
+        let config = TpmConfig {
+            tier: TpmTier::Prod,
+            max_review_cycles: Some(3),
+            disabled_agents: vec!["end-user-simulator".to_string()],
+        };
+
+        write_tpm_config(dir.path(), &config).unwrap();
+
+        let config_path = dir.path().join(".tpm/config.json");
+        assert!(config_path.exists(), "config.json should exist");
+
+        let content = std::fs::read_to_string(&config_path).unwrap();
+        let parsed: TpmConfig = serde_json::from_str(&content).unwrap();
+        assert_eq!(parsed.tier, TpmTier::Prod);
+        assert_eq!(parsed.max_review_cycles, Some(3));
+        assert_eq!(parsed.disabled_agents, vec!["end-user-simulator"]);
+    }
+
+    #[test]
+    fn write_tpm_config_creates_tpm_directory() {
+        let dir = TempDir::new().unwrap();
+        let tpm_dir = dir.path().join(".tpm");
+        assert!(!tpm_dir.exists(), "precondition: .tpm/ should not exist");
+
+        write_tpm_config(dir.path(), &TpmConfig::default()).unwrap();
+        assert!(tpm_dir.is_dir(), ".tpm/ directory should be created");
+    }
+
+    #[test]
+    fn write_tpm_config_default_produces_minimal_json() {
+        let dir = TempDir::new().unwrap();
+        write_tpm_config(dir.path(), &TpmConfig::default()).unwrap();
+
+        let content = std::fs::read_to_string(dir.path().join(".tpm/config.json")).unwrap();
+        let raw: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        // Default config should have tier but omit optional/empty fields
+        assert_eq!(raw["tier"].as_str(), Some("standard"));
+        assert!(
+            raw.get("max_review_cycles").is_none(),
+            "default should omit max_review_cycles"
+        );
+        assert!(
+            raw.get("disabled_agents").is_none(),
+            "default should omit empty disabled_agents"
+        );
+    }
+
     #[test]
     #[serial]
     fn archive_tpm_artifacts_copies_files_and_writes_metadata() {

--- a/src/tpm.rs
+++ b/src/tpm.rs
@@ -648,9 +648,17 @@ pub fn resolve_tpm_dir(instance: &Instance) -> Option<PathBuf> {
     None
 }
 
-/// Replace characters unsafe for filenames with hyphens.
+/// Maximum length of the sanitized title component in archive dir names.
+/// Keeps the full path well under the 255-byte filesystem limit even after
+/// the timestamp and session ID prefix are prepended.
+const MAX_TITLE_LEN: usize = 100;
+
+/// Replace characters unsafe for filenames with hyphens and truncate to
+/// [`MAX_TITLE_LEN`]. Returns an empty string when the input is empty or
+/// contains only special characters; callers should fall back to the
+/// session ID in that case.
 fn sanitize_title(title: &str) -> String {
-    title
+    let sanitized: String = title
         .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
@@ -659,7 +667,27 @@ fn sanitize_title(title: &str) -> String {
                 '-'
             }
         })
-        .collect()
+        .collect();
+    // Trim leading/trailing hyphens so pure-special-char titles collapse to ""
+    let trimmed = sanitized.trim_matches('-');
+    if trimmed.len() > MAX_TITLE_LEN {
+        trimmed[..MAX_TITLE_LEN].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Build the archive directory name: `<timestamp>_<id_prefix>_<title>`.
+/// Falls back to using only the session ID when the sanitized title is empty.
+fn archive_dir_name(now: &chrono::DateTime<chrono::Utc>, instance: &Instance) -> String {
+    let timestamp = now.format("%Y-%m-%dT%H-%M-%S").to_string();
+    let id_prefix = &instance.id[..instance.id.len().min(8)];
+    let safe_title = sanitize_title(&instance.title);
+    if safe_title.is_empty() {
+        format!("{}_{}", timestamp, id_prefix)
+    } else {
+        format!("{}_{}_{}", timestamp, id_prefix, safe_title)
+    }
 }
 
 /// Archive `.tpm/` artifacts to the AoE history directory before worktree
@@ -672,12 +700,11 @@ pub fn archive_tpm_artifacts(instance: &Instance) -> Result<bool> {
         None => return Ok(false),
     };
 
+    let now = chrono::Utc::now();
     let app_dir = crate::session::get_app_dir().context("failed to locate AoE config dir")?;
-    let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H-%M-%S").to_string();
-    let safe_title = sanitize_title(&instance.title);
     let archive_dir = app_dir
         .join("history")
-        .join(format!("{}_{}", timestamp, safe_title));
+        .join(archive_dir_name(&now, instance));
 
     std::fs::create_dir_all(&archive_dir)
         .with_context(|| format!("failed to create {}", archive_dir.display()))?;
@@ -696,7 +723,7 @@ pub fn archive_tpm_artifacts(instance: &Instance) -> Result<bool> {
     let metadata = serde_json::json!({
         "session_id": instance.id,
         "title": instance.title,
-        "archived_at": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "archived_at": now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         "project_path": instance.project_path,
     });
     let metadata_path = archive_dir.join("metadata.json");
@@ -1230,11 +1257,35 @@ mod tests {
         Instance::new(title, project_path)
     }
 
+    /// RAII guard for `$XDG_CONFIG_HOME`. On Linux `dirs::config_dir()` checks
+    /// this first, so we must clear it when redirecting via `HomeGuard` alone
+    /// would be insufficient.
+    struct XdgGuard {
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl XdgGuard {
+        fn unset() -> Self {
+            let prev = std::env::var_os("XDG_CONFIG_HOME");
+            std::env::remove_var("XDG_CONFIG_HOME");
+            Self { prev }
+        }
+    }
+
+    impl Drop for XdgGuard {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(p) => std::env::set_var("XDG_CONFIG_HOME", p),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+
     #[test]
     fn sanitize_title_replaces_unsafe_chars() {
         assert_eq!(sanitize_title("my-task"), "my-task");
         assert_eq!(sanitize_title("feat/new thing"), "feat-new-thing");
-        assert_eq!(sanitize_title("hello world: test!"), "hello-world--test-");
+        assert_eq!(sanitize_title("hello world: test!"), "hello-world--test");
         assert_eq!(
             sanitize_title("dots.and_underscores"),
             "dots.and_underscores"
@@ -1244,6 +1295,54 @@ mod tests {
     #[test]
     fn sanitize_title_empty_string() {
         assert_eq!(sanitize_title(""), "");
+    }
+
+    #[test]
+    fn sanitize_title_all_special_chars() {
+        assert_eq!(sanitize_title("///"), "");
+        assert_eq!(sanitize_title("  "), "");
+    }
+
+    #[test]
+    fn sanitize_title_truncates_long_input() {
+        let long = "a".repeat(200);
+        let result = sanitize_title(&long);
+        assert_eq!(result.len(), MAX_TITLE_LEN);
+    }
+
+    #[test]
+    fn archive_dir_name_falls_back_to_id_on_empty_title() {
+        let instance = create_test_instance("", "/tmp/test");
+        let now = chrono::Utc::now();
+        let name = archive_dir_name(&now, &instance);
+        // Format: <timestamp>_<id_prefix> (no trailing underscore)
+        let id_prefix = &instance.id[..8];
+        assert!(
+            name.ends_with(id_prefix),
+            "expected dir name to end with id prefix {}, got: {}",
+            id_prefix,
+            name
+        );
+        // No double underscore from missing title
+        assert!(
+            !name.contains("__"),
+            "should not have double underscore: {}",
+            name
+        );
+    }
+
+    #[test]
+    fn archive_dir_name_includes_id_and_title() {
+        let instance = create_test_instance("my-task", "/tmp/test");
+        let now = chrono::Utc::now();
+        let name = archive_dir_name(&now, &instance);
+        let id_prefix = &instance.id[..8];
+        assert!(name.contains(id_prefix), "missing id prefix in: {}", name);
+        assert!(
+            name.ends_with("_my-task"),
+            "should end with _my-task, got: {}",
+            name
+        );
     }
 
     #[test]
@@ -1311,7 +1410,12 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn archive_tpm_artifacts_copies_files_and_writes_metadata() {
+        let home_temp = TempDir::new().unwrap();
+        let _home = HomeGuard::set(home_temp.path());
+        let _xdg = XdgGuard::unset();
+
         let project = TempDir::new().unwrap();
         let tpm = project.path().join(".tpm");
         std::fs::create_dir_all(&tpm).unwrap();
@@ -1343,6 +1447,14 @@ mod tests {
         assert!(
             dir_name.ends_with("_my-task"),
             "dir name should end with _my-task, got: {}",
+            dir_name
+        );
+        // Verify session ID prefix is embedded
+        let id_prefix = &instance.id[..8];
+        assert!(
+            dir_name.contains(id_prefix),
+            "dir name should contain id prefix {}, got: {}",
+            id_prefix,
             dir_name
         );
 

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -116,6 +116,8 @@ impl CreationPoller {
             command_override: data.command_override,
             extra_repo_paths: data.extra_repo_paths,
             tpm_tier: data.tpm_tier,
+            tpm_review_passes: data.tpm_review_passes,
+            tpm_disabled_agents: data.tpm_disabled_agents,
         };
 
         let build_result = match builder::build_instance(params, &existing_titles, &profile) {

--- a/src/tui/deletion_poller.rs
+++ b/src/tui/deletion_poller.rs
@@ -67,6 +67,11 @@ impl DeletionPoller {
         // worktrees) are still available for teardown commands.
         Self::run_on_destroy_hooks(&request.instance);
 
+        // Archive .tpm/ artifacts before worktree cleanup destroys them.
+        if let Err(e) = crate::tpm::archive_tpm_artifacts(&request.instance) {
+            tracing::warn!("failed to archive TPM artifacts: {}", e);
+        }
+
         // Track branch info for potential deletion after worktree removal
         let branch_to_delete = if request.delete_branch {
             request

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -56,8 +56,7 @@ pub(super) const FIELD_HELP: &[FieldHelp] = &[
     },
     FieldHelp {
         name: "TPM Mode",
-        description:
-            "Orchestrator tier (fast/standard/prod): autonomously spawns sub-sessions. Space to toggle, Ctrl+P to configure tier",
+        description: "TPM orchestration tier. Space to toggle, Ctrl+P to configure",
     },
     FieldHelp {
         name: "Worktree",
@@ -106,6 +105,10 @@ pub struct NewSessionData {
     /// Boot the session as the TPM orchestrator at the given tier. `None`
     /// means TPM mode is off. See `crate::tpm`.
     pub tpm_tier: Option<crate::tpm::TpmTier>,
+    /// Maximum review/revision cycles (None = use tier default).
+    pub tpm_review_passes: Option<u32>,
+    /// Agent slugs to disable for this TPM session.
+    pub tpm_disabled_agents: Vec<String>,
 }
 
 pub struct NewSessionDialog {
@@ -176,6 +179,12 @@ pub struct NewSessionDialog {
     /// TPM configuration overlay mode (Ctrl+P on TPM field)
     pub(super) tpm_config_mode: bool,
     pub(super) tpm_config_focused_field: usize,
+    /// Maximum review/revision cycles for this TPM session.
+    pub(super) tpm_review_passes: Option<u32>,
+    /// Agent slugs disabled for this TPM session (toggle in overlay).
+    pub(super) tpm_disabled_agents: Vec<String>,
+    /// Text input for editing review passes in the TPM config overlay.
+    pub(super) tpm_review_input: Option<Input>,
     /// Extra args for the selected tool (loaded from config)
     pub(super) extra_args: Input,
     /// Command override for the selected tool (loaded from config)
@@ -444,6 +453,9 @@ impl NewSessionDialog {
             tool_config_focused_field: 0,
             tpm_config_mode: false,
             tpm_config_focused_field: 0,
+            tpm_review_passes: config.tpm.max_review_cycles,
+            tpm_disabled_agents: config.tpm.disabled_agents.clone(),
+            tpm_review_input: None,
             extra_args: Input::new(extra_args_value),
             command_override: Input::new(command_override_value),
             error_message: None,
@@ -640,6 +652,9 @@ impl NewSessionDialog {
         self.tool_config_focused_field = 0;
         self.tpm_config_mode = false;
         self.tpm_config_focused_field = 0;
+        self.tpm_review_passes = config.tpm.max_review_cycles;
+        self.tpm_disabled_agents = config.tpm.disabled_agents.clone();
+        self.tpm_review_input = None;
 
         // Reset expanded states
         self.env_list_expanded = false;
@@ -704,6 +719,9 @@ impl NewSessionDialog {
             tool_config_focused_field: 0,
             tpm_config_mode: false,
             tpm_config_focused_field: 0,
+            tpm_review_passes: None,
+            tpm_disabled_agents: Vec::new(),
+            tpm_review_input: None,
             extra_args: Input::default(),
             command_override: Input::default(),
             error_message: None,
@@ -768,6 +786,9 @@ impl NewSessionDialog {
             tool_config_focused_field: 0,
             tpm_config_mode: false,
             tpm_config_focused_field: 0,
+            tpm_review_passes: None,
+            tpm_disabled_agents: Vec::new(),
+            tpm_review_input: None,
             extra_args: Input::default(),
             command_override: Input::default(),
             error_message: None,
@@ -1299,18 +1320,73 @@ impl NewSessionDialog {
     }
 
     /// Handle key events when in TPM configuration mode.
+    ///
+    /// The overlay has three sections:
+    ///   0: Tier radio selector (Left/Right to cycle)
+    ///   1: Review passes (number input)
+    ///   2+: Agent toggles (Space to toggle, one per known agent)
     fn handle_tpm_config_key(&mut self, key: KeyEvent) -> DialogResult<NewSessionData> {
-        // TPM config has a single field: tier radio selector
+        // If editing review passes number, handle text input first
+        if let Some(ref mut input) = self.tpm_review_input {
+            match key.code {
+                KeyCode::Esc => {
+                    self.tpm_review_input = None;
+                    return DialogResult::Continue;
+                }
+                KeyCode::Enter => {
+                    let text = input.value().trim().to_string();
+                    if text.is_empty() || text == "0" {
+                        self.tpm_review_passes = None;
+                    } else if let Ok(n) = text.parse::<u32>() {
+                        self.tpm_review_passes = Some(n);
+                    }
+                    self.tpm_review_input = None;
+                    return DialogResult::Continue;
+                }
+                _ => {
+                    input.handle_event(&crossterm::event::Event::Key(key));
+                    return DialogResult::Continue;
+                }
+            }
+        }
+
+        // Total fields: 0=tier, 1=review passes, 2..2+N-1=agent toggles
+        let agent_count = crate::tpm::KNOWN_AGENTS.len();
+        let max_field = 2 + agent_count;
+
         match key.code {
-            KeyCode::Esc | KeyCode::Enter => {
+            KeyCode::Esc => {
                 self.tpm_config_mode = false;
+                DialogResult::Continue
+            }
+            KeyCode::Enter => {
+                if self.tpm_config_focused_field == 1 {
+                    // Edit review passes
+                    let current = self.tpm_review_passes.unwrap_or(0);
+                    self.tpm_review_input = Some(Input::new(current.to_string()));
+                } else {
+                    self.tpm_config_mode = false;
+                }
                 DialogResult::Continue
             }
             KeyCode::Char('?') => {
                 self.show_help = true;
                 DialogResult::Continue
             }
-            KeyCode::Left | KeyCode::Right => {
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.tpm_config_focused_field > 0 {
+                    self.tpm_config_focused_field -= 1;
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if self.tpm_config_focused_field < max_field - 1 {
+                    self.tpm_config_focused_field += 1;
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Left | KeyCode::Right if self.tpm_config_focused_field == 0 => {
+                // Tier radio selector
                 if let Some(tier) = self.tpm_tier {
                     use crate::tpm::TpmTier;
                     self.tpm_tier = Some(match (tier, key.code) {
@@ -1322,6 +1398,22 @@ impl NewSessionDialog {
                         (TpmTier::Prod, KeyCode::Left) => TpmTier::Standard,
                         _ => tier,
                     });
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Char(' ') if self.tpm_config_focused_field >= 2 => {
+                // Agent toggle
+                let agent_idx = self.tpm_config_focused_field - 2;
+                if agent_idx < agent_count {
+                    let slug = crate::tpm::KNOWN_AGENTS[agent_idx];
+                    // Implementer cannot be disabled
+                    if slug != "implementer" {
+                        if let Some(pos) = self.tpm_disabled_agents.iter().position(|a| a == slug) {
+                            self.tpm_disabled_agents.remove(pos);
+                        } else {
+                            self.tpm_disabled_agents.push(slug.to_string());
+                        }
+                    }
                 }
                 DialogResult::Continue
             }
@@ -1595,6 +1687,16 @@ impl NewSessionDialog {
                 self.tpm_tier
             } else {
                 None
+            },
+            tpm_review_passes: if self.show_tpm_toggle() && self.tpm_tier.is_some() {
+                self.tpm_review_passes
+            } else {
+                None
+            },
+            tpm_disabled_agents: if self.show_tpm_toggle() && self.tpm_tier.is_some() {
+                self.tpm_disabled_agents.clone()
+            } else {
+                Vec::new()
             },
         })
     }

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -1343,8 +1343,21 @@ impl NewSessionDialog {
                     self.tpm_review_input = None;
                     return DialogResult::Continue;
                 }
-                _ => {
+                KeyCode::Char(c) if c.is_ascii_digit() => {
                     input.handle_event(&crossterm::event::Event::Key(key));
+                    return DialogResult::Continue;
+                }
+                KeyCode::Backspace
+                | KeyCode::Delete
+                | KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::Home
+                | KeyCode::End => {
+                    input.handle_event(&crossterm::event::Event::Key(key));
+                    return DialogResult::Continue;
+                }
+                _ => {
+                    // Reject non-digit characters silently
                     return DialogResult::Continue;
                 }
             }

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -982,11 +982,15 @@ impl NewSessionDialog {
     }
 
     fn render_tpm_config(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let dialog_width: u16 = 52;
+        let dialog_width: u16 = 58;
+        let agent_count = crate::tpm::KNOWN_AGENTS.len() as u16;
 
         let constraints = vec![
-            Constraint::Length(2), // Tier radio selector
-            Constraint::Min(1),    // Hints
+            Constraint::Length(2),           // Tier radio selector
+            Constraint::Length(2),           // Review passes
+            Constraint::Length(1),           // Agents header
+            Constraint::Length(agent_count), // Agent toggles
+            Constraint::Min(1),              // Hints
         ];
 
         let fields_height: u16 = constraints
@@ -1019,12 +1023,18 @@ impl NewSessionDialog {
             .constraints(constraints)
             .split(inner);
 
-        // Tier radio buttons
+        let focused = self.tpm_config_focused_field;
+
+        // 0: Tier radio buttons
         {
             use crate::tpm::TpmTier;
             let current = self.tpm_tier.unwrap_or(TpmTier::Standard);
-            let label_style = Style::default().fg(theme.accent).underlined();
-            let mut spans = vec![Span::styled("Tier:", label_style), Span::raw(" ")];
+            let label_style = if focused == 0 {
+                Style::default().fg(theme.accent).underlined()
+            } else {
+                Style::default().fg(theme.text)
+            };
+            let mut spans = vec![Span::styled("Tier:", label_style), Span::raw("     ")];
 
             for (i, (tier, label)) in [
                 (TpmTier::Fast, "fast"),
@@ -1050,16 +1060,122 @@ impl NewSessionDialog {
             frame.render_widget(Paragraph::new(Line::from(spans)), chunks[0]);
         }
 
-        // Hints
+        // 1: Review passes
+        {
+            let label_style = if focused == 1 {
+                Style::default().fg(theme.accent).underlined()
+            } else {
+                Style::default().fg(theme.text)
+            };
+
+            if let Some(ref input) = self.tpm_review_input {
+                // Editing mode
+                let spans = vec![
+                    Span::styled("Reviews:", label_style),
+                    Span::raw(" "),
+                    Span::styled(
+                        input.value(),
+                        Style::default().fg(theme.accent).underlined(),
+                    ),
+                    Span::styled("_", Style::default().fg(theme.accent)),
+                ];
+                frame.render_widget(Paragraph::new(Line::from(spans)), chunks[1]);
+            } else {
+                let value_str = match self.tpm_review_passes {
+                    Some(n) if n > 0 => n.to_string(),
+                    _ => "tier default".to_string(),
+                };
+                let value_style = if focused == 1 {
+                    Style::default().fg(theme.accent)
+                } else {
+                    Style::default().fg(theme.dimmed)
+                };
+                let spans = vec![
+                    Span::styled("Reviews:", label_style),
+                    Span::raw(" "),
+                    Span::styled(value_str, value_style),
+                ];
+                frame.render_widget(Paragraph::new(Line::from(spans)), chunks[1]);
+            }
+        }
+
+        // 2: Agents header
+        {
+            let header_style = Style::default().fg(theme.text).bold();
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled("Agents:", header_style))),
+                chunks[2],
+            );
+        }
+
+        // 3: Agent toggles
+        {
+            let mut lines: Vec<Line> = Vec::new();
+            for (i, slug) in crate::tpm::KNOWN_AGENTS.iter().enumerate() {
+                let field_idx = 2 + i;
+                let is_implementer = *slug == "implementer";
+                let is_disabled = self.tpm_disabled_agents.iter().any(|a| a == slug);
+                let is_focused = focused == field_idx;
+
+                let checkbox = if is_implementer {
+                    // Implementer is always enabled, shown greyed out
+                    Span::styled("[x] ", Style::default().fg(theme.dimmed))
+                } else if is_disabled {
+                    let style = if is_focused {
+                        Style::default().fg(theme.accent)
+                    } else {
+                        Style::default().fg(theme.dimmed)
+                    };
+                    Span::styled("[ ] ", style)
+                } else {
+                    let style = if is_focused {
+                        Style::default().fg(theme.accent)
+                    } else {
+                        Style::default().fg(theme.text)
+                    };
+                    Span::styled("[x] ", style)
+                };
+
+                let name_style = if is_implementer {
+                    Style::default().fg(theme.dimmed)
+                } else if is_focused {
+                    Style::default().fg(theme.accent).bold()
+                } else if is_disabled {
+                    Style::default().fg(theme.dimmed)
+                } else {
+                    Style::default().fg(theme.text)
+                };
+
+                let suffix = if is_implementer {
+                    Span::styled(" (always on)", Style::default().fg(theme.dimmed))
+                } else {
+                    Span::raw("")
+                };
+
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    checkbox,
+                    Span::styled(*slug, name_style),
+                    suffix,
+                ]));
+            }
+            frame.render_widget(Paragraph::new(lines), chunks[3]);
+        }
+
+        // 4: Hints
         let hint_spans = vec![
+            Span::styled("↑/↓", Style::default().fg(theme.hint)),
+            Span::raw(" navigate  "),
             Span::styled("←/→", Style::default().fg(theme.hint)),
-            Span::raw(" cycle  "),
+            Span::raw(" cycle tier  "),
+            Span::styled("Space", Style::default().fg(theme.hint)),
+            Span::raw(" toggle  "),
             Span::styled("Enter", Style::default().fg(theme.hint)),
-            Span::raw(" done  "),
+            Span::raw(" edit/done  "),
             Span::styled("Esc", Style::default().fg(theme.hint)),
             Span::raw(" back"),
         ];
-        frame.render_widget(Paragraph::new(Line::from(hint_spans)), chunks[1]);
+        frame.render_widget(Paragraph::new(Line::from(hint_spans)), chunks[4]);
 
         if self.show_help {
             self.render_help_overlay(frame, area, theme);

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -38,6 +38,8 @@ impl HomeView {
             command_override: data.command_override,
             extra_repo_paths: data.extra_repo_paths,
             tpm_tier: data.tpm_tier,
+            tpm_review_passes: data.tpm_review_passes,
+            tpm_disabled_agents: data.tpm_disabled_agents,
         };
 
         let build_result = builder::build_instance(params, &existing_titles, &target_profile)?;

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -464,6 +464,12 @@ impl HomeView {
 
         if let Item::Session { id, .. } = item {
             if let Some(inst) = self.get_instance(id) {
+                if inst.tpm_managed {
+                    line_spans.push(Span::styled(
+                        " TPM",
+                        Style::default().fg(theme.accent).bold(),
+                    ));
+                }
                 if let Some(ws_info) = &inst.workspace_info {
                     line_spans.push(Span::styled(
                         format!("  {} [{} repos]", ws_info.branch, ws_info.repos.len()),

--- a/src/tui/home/state_panel.rs
+++ b/src/tui/home/state_panel.rs
@@ -10,6 +10,7 @@ use std::time::Instant;
 
 use ratatui::prelude::*;
 use ratatui::widgets::*;
+use unicode_width::UnicodeWidthStr;
 
 use crate::session::Instance;
 use crate::tui::styles::Theme;
@@ -426,12 +427,12 @@ fn wrap_line(text: &str, style: Style, width: usize, indent: &str) -> Vec<Line<'
     let mut first = true;
 
     while !remaining.is_empty() {
-        let max = if first {
+        let max_cols = if first {
             width
         } else {
-            width.saturating_sub(indent.len())
+            width.saturating_sub(UnicodeWidthStr::width(indent))
         };
-        if remaining.len() <= max {
+        if UnicodeWidthStr::width(remaining) <= max_cols {
             let line_text = if first {
                 remaining.to_string()
             } else {
@@ -441,11 +442,14 @@ fn wrap_line(text: &str, style: Style, width: usize, indent: &str) -> Vec<Line<'
             break;
         }
 
-        // Find a word boundary to break at
-        let break_at = remaining[..max]
+        // Find the byte offset where cumulative display width reaches max_cols.
+        let byte_limit = byte_offset_for_width(remaining, max_cols);
+
+        // Find a word boundary (space) to break at within that range.
+        let break_at = remaining[..byte_limit]
             .rfind(' ')
             .map(|pos| pos + 1)
-            .unwrap_or(max);
+            .unwrap_or(byte_limit);
 
         let (chunk, rest) = remaining.split_at(break_at);
         let line_text = if first {
@@ -463,6 +467,21 @@ fn wrap_line(text: &str, style: Style, width: usize, indent: &str) -> Vec<Line<'
     }
 
     result
+}
+
+/// Return the byte offset into `s` such that the substring `s[..offset]`
+/// has a display width of at most `max_cols` columns and `offset` falls
+/// on a char boundary.
+fn byte_offset_for_width(s: &str, max_cols: usize) -> usize {
+    let mut cols = 0;
+    for (i, c) in s.char_indices() {
+        let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+        if cols + w > max_cols {
+            return i;
+        }
+        cols += w;
+    }
+    s.len()
 }
 
 #[cfg(test)]
@@ -602,5 +621,42 @@ mod tests {
         let table = vec!["| foo | barbaz |", "|---|---|", "| a | b |"];
         let widths = compute_table_col_widths(&table, 80);
         assert_eq!(widths, vec![3, 6]); // "foo"=3, "barbaz"=6
+    }
+
+    #[test]
+    fn test_wrap_line_multibyte_no_panic() {
+        let style = Style::default();
+        // Em-dash is 3 bytes in UTF-8; wrapping must not panic on it.
+        let text = "Planning phase \u{2014} determine the requirements for the feature";
+        let result = wrap_line(text, style, 20, "");
+        assert!(result.len() > 1);
+        for line in &result {
+            assert!(line.width() <= 20);
+        }
+    }
+
+    #[test]
+    fn test_wrap_line_cjk_chars() {
+        let style = Style::default();
+        // CJK characters are 2 columns wide each.
+        let text = "\u{4f60}\u{597d}\u{4e16}\u{754c} hello";
+        let result = wrap_line(text, style, 10, "");
+        assert!(!result.is_empty());
+        for line in &result {
+            assert!(line.width() <= 10);
+        }
+    }
+
+    #[test]
+    fn test_byte_offset_for_width() {
+        // ASCII: 1 byte = 1 column
+        assert_eq!(byte_offset_for_width("hello", 3), 3);
+        // Em-dash (\u{2014}) is 1 column wide, 3 bytes
+        assert_eq!(byte_offset_for_width("\u{2014}abc", 1), 3);
+        // CJK char is 2 columns wide, 3 bytes
+        assert_eq!(byte_offset_for_width("\u{4f60}x", 1), 0);
+        assert_eq!(byte_offset_for_width("\u{4f60}x", 2), 3);
+        // Width larger than string returns full length
+        assert_eq!(byte_offset_for_width("hi", 10), 2);
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1846,6 +1846,8 @@ fn test_create_session_in_all_mode_is_findable() {
         extra_args: String::new(),
         command_override: String::new(),
         tpm_tier: None,
+        tpm_review_passes: None,
+        tpm_disabled_agents: Vec::new(),
     };
 
     let session_id = view.create_session(data).unwrap();
@@ -2507,6 +2509,8 @@ fn test_apply_creation_results_returns_session_id() {
         extra_args: String::new(),
         command_override: String::new(),
         tpm_tier: None,
+        tpm_review_passes: None,
+        tpm_disabled_agents: Vec::new(),
     };
 
     // Use the async CreationPoller path (pass None hooks, non-sandbox,

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -22,6 +22,7 @@ pub enum SettingsCategory {
     Session,
     Sound,
     Hooks,
+    Tpm,
 }
 
 impl SettingsCategory {
@@ -35,6 +36,7 @@ impl SettingsCategory {
             Self::Session => "Session",
             Self::Sound => "Sound",
             Self::Hooks => "Hooks",
+            Self::Tpm => "TPM",
         }
     }
 }
@@ -92,6 +94,10 @@ pub enum FieldKey {
     HookOnCreate,
     HookOnLaunch,
     HookOnDestroy,
+    // TPM
+    TpmDefaultTier,
+    TpmMaxReviewCycles,
+    TpmDisabledAgents,
 }
 
 /// Resolve a field value from global config and optional profile override.
@@ -252,6 +258,7 @@ pub fn build_fields_for_category(
         SettingsCategory::Session => build_session_fields(scope, global, profile),
         SettingsCategory::Sound => build_sound_fields(scope, global, profile),
         SettingsCategory::Hooks => build_hooks_fields(scope, global, profile),
+        SettingsCategory::Tpm => build_tpm_fields(scope, global, profile),
     }
 }
 
@@ -1253,6 +1260,87 @@ fn build_hooks_fields(
     ]
 }
 
+fn build_tpm_fields(
+    scope: SettingsScope,
+    global: &Config,
+    profile: &ProfileConfig,
+) -> Vec<SettingField> {
+    let tpm = profile.tpm.as_ref();
+
+    let (tier, o1) = resolve_value(scope, global.tpm.tier, tpm.and_then(|t| t.tier));
+
+    let tier_selected = match tier {
+        crate::tpm::TpmTier::Fast => 0,
+        crate::tpm::TpmTier::Standard => 1,
+        crate::tpm::TpmTier::Prod => 2,
+    };
+    let global_tier_selected = match global.tpm.tier {
+        crate::tpm::TpmTier::Fast => 0,
+        crate::tpm::TpmTier::Standard => 1,
+        crate::tpm::TpmTier::Prod => 2,
+    };
+    let tier_options = vec!["Fast".into(), "Standard".into(), "Prod".into()];
+
+    // max_review_cycles: Option<u32> in TpmConfig, Option<Option<u32>> in override
+    let (max_review_cycles, o2) = resolve_value(
+        scope,
+        global.tpm.max_review_cycles.unwrap_or(0) as u64,
+        tpm.and_then(|t| t.max_review_cycles.map(|v| v.unwrap_or(0) as u64)),
+    );
+
+    // disabled_agents: Vec<String> displayed as comma-separated text
+    let (disabled_agents, o3) = resolve_value(
+        scope,
+        global.tpm.disabled_agents.clone(),
+        tpm.and_then(|t| t.disabled_agents.clone()),
+    );
+    let disabled_agents_text = disabled_agents.join(", ");
+    let global_disabled_agents_text = global.tpm.disabled_agents.join(", ");
+
+    vec![
+        SettingField {
+            key: FieldKey::TpmDefaultTier,
+            label: "Default Tier",
+            description: "Orchestration tier for new TPM sessions (fast/standard/prod)",
+            value: FieldValue::Select {
+                selected: tier_selected,
+                options: tier_options.clone(),
+            },
+            category: SettingsCategory::Tpm,
+            has_override: o1,
+            inherited_display: inherited_if(
+                o1,
+                FieldValue::Select {
+                    selected: global_tier_selected,
+                    options: tier_options,
+                },
+            ),
+        },
+        SettingField {
+            key: FieldKey::TpmMaxReviewCycles,
+            label: "Max Review Cycles",
+            description: "Maximum review/revision cycles (0 = use tier default)",
+            value: FieldValue::Number(max_review_cycles),
+            category: SettingsCategory::Tpm,
+            has_override: o2,
+            inherited_display: inherited_if(
+                o2,
+                FieldValue::Number(global.tpm.max_review_cycles.unwrap_or(0) as u64),
+            ),
+        },
+        SettingField {
+            key: FieldKey::TpmDisabledAgents,
+            label: "Disabled Agents",
+            description:
+                "Comma-separated agent slugs to disable (e.g. principal-engineer, end-user-simulator). Implementer cannot be disabled.",
+            value: FieldValue::Text(disabled_agents_text),
+            category: SettingsCategory::Tpm,
+            has_override: o3,
+            inherited_display: inherited_if(o3, FieldValue::Text(global_disabled_agents_text)),
+        },
+    ]
+}
+
 /// Apply a field's value back to the appropriate config.
 /// For profile scope, the value is always stored as an override.
 pub fn apply_field_to_config(
@@ -1393,8 +1481,31 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::HookOnCreate, FieldValue::List(v)) => config.hooks.on_create = v.clone(),
         (FieldKey::HookOnLaunch, FieldValue::List(v)) => config.hooks.on_launch = v.clone(),
         (FieldKey::HookOnDestroy, FieldValue::List(v)) => config.hooks.on_destroy = v.clone(),
+        // TPM
+        (FieldKey::TpmDefaultTier, FieldValue::Select { selected, .. }) => {
+            config.tpm.tier = match selected {
+                0 => crate::tpm::TpmTier::Fast,
+                2 => crate::tpm::TpmTier::Prod,
+                _ => crate::tpm::TpmTier::Standard,
+            };
+        }
+        (FieldKey::TpmMaxReviewCycles, FieldValue::Number(v)) => {
+            config.tpm.max_review_cycles = if *v == 0 { None } else { Some(*v as u32) };
+        }
+        (FieldKey::TpmDisabledAgents, FieldValue::Text(v)) => {
+            config.tpm.disabled_agents = parse_comma_separated_agents(v);
+        }
         _ => {}
     }
+}
+
+/// Parse a comma-separated string of agent slugs into a Vec, filtering out
+/// empty entries, whitespace, and the always-enabled "implementer" slug.
+fn parse_comma_separated_agents(text: &str) -> Vec<String> {
+    text.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && s != "implementer")
+        .collect()
 }
 
 /// Apply a field to the profile config.
@@ -1640,6 +1751,27 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
         }
         (FieldKey::HookOnDestroy, FieldValue::List(v)) => {
             set_profile_override(v.clone(), &mut config.hooks, |s, val| s.on_destroy = val);
+        }
+        // TPM
+        (FieldKey::TpmDefaultTier, FieldValue::Select { selected, .. }) => {
+            let tier = match selected {
+                0 => crate::tpm::TpmTier::Fast,
+                2 => crate::tpm::TpmTier::Prod,
+                _ => crate::tpm::TpmTier::Standard,
+            };
+            set_profile_override(tier, &mut config.tpm, |s, val| s.tier = val);
+        }
+        (FieldKey::TpmMaxReviewCycles, FieldValue::Number(v)) => {
+            let cycles = if *v == 0 { None } else { Some(*v as u32) };
+            use crate::session::TpmConfigOverride;
+            let s = config.tpm.get_or_insert_with(TpmConfigOverride::default);
+            s.max_review_cycles = Some(cycles);
+        }
+        (FieldKey::TpmDisabledAgents, FieldValue::Text(v)) => {
+            let agents = parse_comma_separated_agents(v);
+            use crate::session::TpmConfigOverride;
+            let s = config.tpm.get_or_insert_with(TpmConfigOverride::default);
+            s.disabled_agents = Some(agents);
         }
         _ => {}
     }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -748,6 +748,22 @@ impl SettingsView {
                     h.on_destroy = None;
                 }
             }
+            // TPM
+            FieldKey::TpmDefaultTier => {
+                if let Some(ref mut t) = config.tpm {
+                    t.tier = None;
+                }
+            }
+            FieldKey::TpmMaxReviewCycles => {
+                if let Some(ref mut t) = config.tpm {
+                    t.max_review_cycles = None;
+                }
+            }
+            FieldKey::TpmDisabledAgents => {
+                if let Some(ref mut t) = config.tpm {
+                    t.disabled_agents = None;
+                }
+            }
         }
 
         // Sync repo_config when in Repo scope

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -143,6 +143,7 @@ impl SettingsView {
             SettingsCategory::Updates,
             SettingsCategory::Tmux,
             SettingsCategory::Sound,
+            SettingsCategory::Tpm,
         ];
 
         let mut view = Self {


### PR DESCRIPTION
## Description

Implements three GitHub issues for TPM (Technical Project Manager) integration, plus a bugfix found during testing:

- **#15 TPM visual indicator**: TPM-managed sessions display a `[TPM]` badge in the session list. Migration v005 sets `tpm_managed` on existing sessions that have a `.tpm/` directory.
- **#16 TPM configuration panel**: New "TPM" category in Settings TUI with tier, max review cycles, and disabled agents fields. New-session dialog gains a Ctrl+P overlay for per-session TPM overrides. CLI flags `--tpm-review-passes` and `--tpm-disable-agent`. Orchestrator prompt updated to read `.tpm/config.json` and honor overrides.
- **#17 STATE.md archival**: When a TPM-managed session is deleted, `.tpm/` artifacts are archived to `~/.config/agent-of-empires/history/<sanitized-title>-<timestamp>/`.
- **Hotfix**: Unicode-aware text wrapping in STATE.md panel (`state_panel.rs`) to prevent panics on multi-byte characters.

Closes #15, closes #16, closes #17.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Tasks

| Wave | Task | Description |
|------|------|-------------|
| 1 | task-01 | TPM badge indicator in session list (#15) |
| 1 | task-02 | Archive .tpm/ artifacts on session deletion (#17) |
| 2 | task-03 | TPM configuration panel with settings, overlay, and CLI flags (#16) |
| 3 | task-04 | Wire TpmConfig into orchestrator prompt (#16) |
| 3 | task-05 | TPM unit tests for serde, config, and profile merge (#15, #16, #17) |

## QA Results

- 1294 tests passed, 0 failures
- `cargo build`: clean
- `cargo clippy -- -D warnings`: 0 warnings
- `cargo fmt --check`: clean
- 12 new TPM-specific tests added

## Deferred Issues

Minor items deferred to follow-up PRs (documented in `.tpm/deferred-issues.md`):
- Web API missing `tpm_managed` field (TUI-only for now)
- `ARCHIVABLE_FILES` list could be extended beyond the 4 core files
- `Option<Option<u32>>` TOML roundtrip lossy for "explicitly cleared" semantics
- Orchestrator wording ambiguities in config.json documentation

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via TPM orchestrator (tpm-workflow plugin for Agent of Empires)

**Any Additional AI Details you'd like to share:** 5 tasks across 3 waves, dispatched as parallel AoE sessions with adversarial trio review (blind/edge/acceptance) per task. 3 review cycles on task-04 due to a catastrophic revision that was caught and reverted.

- [x] I am an AI Agent filling out this form (check box if true)
