### PR TITLE
feat(tui): backlog TUI enhancements (#19, #21, #27, #30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-of-empires"
-version = "1.4.1"
+version = "1.4.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -121,13 +121,15 @@ pub enum GroupByMode {
     #[default]
     Manual,
     Project,
+    Tpm,
 }
 
 impl GroupByMode {
     pub fn cycle(self) -> Self {
         match self {
             GroupByMode::Manual => GroupByMode::Project,
-            GroupByMode::Project => GroupByMode::Manual,
+            GroupByMode::Project => GroupByMode::Tpm,
+            GroupByMode::Tpm => GroupByMode::Manual,
         }
     }
 
@@ -135,6 +137,7 @@ impl GroupByMode {
         match self {
             GroupByMode::Manual => "Manual",
             GroupByMode::Project => "Project",
+            GroupByMode::Tpm => "TPM",
         }
     }
 }
@@ -1175,5 +1178,48 @@ mod tests {
             deserialized.session.agent_detect_as.get("lenovo-claude"),
             Some(&"claude".to_string()),
         );
+    }
+
+    #[test]
+    fn test_group_by_mode_tpm_serialization_roundtrip() {
+        // AC-01: Tpm variant serializes as "tpm" and deserializes back
+        let mode = GroupByMode::Tpm;
+        let json = serde_json::to_string(&mode).unwrap();
+        assert_eq!(json, r#""tpm""#);
+        let deserialized: GroupByMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, GroupByMode::Tpm);
+    }
+
+    #[test]
+    fn test_group_by_mode_cycle_three_way() {
+        // AC-01: cycle goes Manual -> Project -> Tpm -> Manual
+        assert_eq!(GroupByMode::Manual.cycle(), GroupByMode::Project);
+        assert_eq!(GroupByMode::Project.cycle(), GroupByMode::Tpm);
+        assert_eq!(GroupByMode::Tpm.cycle(), GroupByMode::Manual);
+    }
+
+    #[test]
+    fn test_group_by_mode_tpm_label() {
+        assert_eq!(GroupByMode::Tpm.label(), "TPM");
+    }
+
+    #[test]
+    fn test_group_by_mode_backwards_compat_deserialization() {
+        // AC-02: existing "manual" and "project" values still deserialize
+        let manual: GroupByMode = serde_json::from_str(r#""manual""#).unwrap();
+        assert_eq!(manual, GroupByMode::Manual);
+        let project: GroupByMode = serde_json::from_str(r#""project""#).unwrap();
+        assert_eq!(project, GroupByMode::Project);
+    }
+
+    #[test]
+    fn test_group_by_mode_tpm_in_app_state_toml() {
+        // Tpm variant persists correctly in TOML config
+        let toml_str = r#"
+            [app_state]
+            group_by = "tpm"
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.app_state.group_by, Some(GroupByMode::Tpm));
     }
 }

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -1150,4 +1150,50 @@ mod tests {
 
         assert!(tree.group_exists("work"));
     }
+
+    #[test]
+    fn test_flatten_with_tpm_style_group_names() {
+        // Simulates what build_flat_items_by_tpm() does: child sessions get
+        // group_path set to the parent session's title, while the orchestrator
+        // session stays ungrouped (empty group_path).
+        let orchestrator = Instance::new("my-orchestrator", "/tmp/orch");
+        let mut child1 = Instance::new("child-1", "/tmp/c1");
+        child1.group_path = "my-orchestrator".to_string();
+        let mut child2 = Instance::new("child-2", "/tmp/c2");
+        child2.group_path = "my-orchestrator".to_string();
+
+        let instances = vec![orchestrator, child1, child2];
+        let tree = GroupTree::new_with_groups(&instances, &[]);
+        let items = flatten_tree(&tree, &instances, SortOrder::Oldest);
+
+        // Expect: 1 ungrouped session (orchestrator) + 1 group header + 2 children
+        let groups: Vec<_> = items
+            .iter()
+            .filter(|i| matches!(i, Item::Group { .. }))
+            .collect();
+        assert_eq!(groups.len(), 1, "should have exactly 1 group");
+
+        if let Item::Group {
+            name,
+            session_count,
+            ..
+        } = &groups[0]
+        {
+            assert_eq!(name, "my-orchestrator");
+            assert_eq!(*session_count, 2, "group should count 2 direct children");
+        }
+
+        let sessions: Vec<_> = items
+            .iter()
+            .filter(|i| matches!(i, Item::Session { .. }))
+            .collect();
+        assert_eq!(sessions.len(), 3, "should have 3 sessions total");
+
+        // First item is the ungrouped orchestrator at depth 0
+        if let Item::Session { depth, .. } = &items[0] {
+            assert_eq!(*depth, 0, "orchestrator should be at depth 0");
+        } else {
+            panic!("first item should be a session (orchestrator)");
+        }
+    }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -113,6 +113,14 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_accessed_at: Option<DateTime<Utc>>,
 
+    /// When the session last transitioned to Idle status. Set when status
+    /// changes from non-Idle to Idle; cleared on reverse transition.
+    /// Used with `last_accessed_at` to implement an "unread notification"
+    /// indicator: if idle_since > last_accessed_at, the user hasn't seen
+    /// this idle session yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_since: Option<DateTime<Utc>>,
+
     // Git worktree integration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_info: Option<WorktreeInfo>,
@@ -162,6 +170,7 @@ impl Instance {
             status: Status::Idle,
             created_at: Utc::now(),
             last_accessed_at: None,
+            idle_since: None,
             worktree_info: None,
             workspace_info: None,
             sandbox_info: None,
@@ -171,6 +180,23 @@ impl Instance {
             last_error_check: None,
             last_start_time: None,
             last_error: None,
+        }
+    }
+
+    /// Returns true when this session went idle after the user last viewed it,
+    /// implementing an "unread notification" indicator. Only returns true for
+    /// sessions currently in Idle status to avoid stale indicators on Error or
+    /// Stopped sessions.
+    pub fn needs_attention(&self) -> bool {
+        if self.status != Status::Idle {
+            return false;
+        }
+        match self.idle_since {
+            None => false,
+            Some(idle_ts) => match self.last_accessed_at {
+                None => true,
+                Some(accessed_ts) => idle_ts > accessed_ts,
+            },
         }
     }
 
@@ -1497,5 +1523,100 @@ mod tests {
 
         // Longer names like "opencode" should still match.
         assert!(pane_has_agent_content("OpenCode v1.0", "opencode"));
+    }
+
+    // -----------------------------------------------------------------------
+    // needs_attention() tests (AC-01, AC-03)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_needs_attention_idle_since_set_last_accessed_none() {
+        // AC-01: idle_since = Some(T1), last_accessed_at = None => true
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Idle;
+        inst.idle_since = Some(Utc::now());
+        inst.last_accessed_at = None;
+        assert!(inst.needs_attention());
+    }
+
+    #[test]
+    fn test_needs_attention_idle_after_last_access() {
+        // AC-01: idle_since = Some(T2), last_accessed_at = Some(T1), T2 > T1 => true
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Idle;
+        let t1 = Utc::now() - chrono::Duration::seconds(60);
+        let t2 = Utc::now();
+        inst.last_accessed_at = Some(t1);
+        inst.idle_since = Some(t2);
+        assert!(inst.needs_attention());
+    }
+
+    #[test]
+    fn test_needs_attention_accessed_after_idle() {
+        // AC-01: last_accessed_at = Some(T3), idle_since = Some(T2), T3 > T2 => false
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Idle;
+        let t2 = Utc::now() - chrono::Duration::seconds(60);
+        let t3 = Utc::now();
+        inst.idle_since = Some(t2);
+        inst.last_accessed_at = Some(t3);
+        assert!(!inst.needs_attention());
+    }
+
+    #[test]
+    fn test_needs_attention_idle_since_none() {
+        // AC-01: idle_since = None => false
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Idle;
+        inst.idle_since = None;
+        assert!(!inst.needs_attention());
+    }
+
+    #[test]
+    fn test_needs_attention_false_for_non_idle_statuses() {
+        // AC-03: non-Idle statuses return false even if idle_since is set
+        let non_idle = [
+            Status::Running,
+            Status::Waiting,
+            Status::Unknown,
+            Status::Stopped,
+            Status::Error,
+            Status::Starting,
+            Status::Deleting,
+            Status::Creating,
+        ];
+        for status in non_idle {
+            let mut inst = Instance::new("test", "/tmp/test");
+            inst.status = status;
+            inst.idle_since = Some(Utc::now());
+            inst.last_accessed_at = None;
+            assert!(
+                !inst.needs_attention(),
+                "needs_attention() should be false for {:?}",
+                status
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Backwards compatibility deserialization test (AC-02)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_deserialize_instance_without_idle_since() {
+        // AC-02: session JSON without idle_since deserializes with idle_since = None
+        let json = r#"{
+            "id": "abc123def456abcd",
+            "title": "old-session",
+            "project_path": "/tmp/test",
+            "command": "",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00Z"
+        }"#;
+        let inst: Instance = serde_json::from_str(json).unwrap();
+        assert_eq!(inst.title, "old-session");
+        assert!(inst.idle_since.is_none());
+        assert!(inst.last_accessed_at.is_none());
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -141,6 +141,12 @@ pub struct Instance {
     #[serde(default)]
     pub tpm_managed: bool,
 
+    /// Claude Code session ID for `--resume` on restart. Discovered from
+    /// Claude's filesystem (`~/.claude/projects/<project-key>/`) and cleared
+    /// after a successful resume start to avoid stale IDs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_session_id: Option<String>,
+
     /// Runtime-only: which profile this instance was loaded from. Not persisted to disk.
     #[serde(default, skip_serializing)]
     pub source_profile: String,
@@ -176,6 +182,7 @@ impl Instance {
             sandbox_info: None,
             terminal_info: None,
             tpm_managed: false,
+            claude_session_id: None,
             source_profile: String::new(),
             last_error_check: None,
             last_start_time: None,
@@ -198,6 +205,64 @@ impl Instance {
                 Some(accessed_ts) => idle_ts > accessed_ts,
             },
         }
+    }
+
+    /// Compute the Claude Code project key for this session's `project_path`.
+    ///
+    /// Claude Code identifies projects by canonicalizing the path and replacing
+    /// each `/` with `-`. For example, `/home/user/my-project` becomes
+    /// `-home-user-my-project`. Returns `None` if the path cannot be canonicalized.
+    pub fn claude_project_hash(&self) -> Option<String> {
+        std::fs::canonicalize(&self.project_path)
+            .ok()
+            .map(|p| p.to_string_lossy().replace('/', "-"))
+    }
+
+    /// Discover the most recent Claude Code session ID for this project.
+    ///
+    /// Looks in `~/.claude/projects/<project-key>/` for `.jsonl` session log
+    /// files, finds the one with the most recent modification time, and returns
+    /// its UUID (the filename stem). Returns `None` when the directory doesn't
+    /// exist, is empty, or on any filesystem error.
+    pub fn discover_claude_session_id(&self) -> Option<String> {
+        let project_key = self.claude_project_hash()?;
+        let claude_dir = dirs::home_dir()?
+            .join(".claude")
+            .join("projects")
+            .join(&project_key);
+
+        if !claude_dir.is_dir() {
+            return None;
+        }
+
+        let entries = std::fs::read_dir(&claude_dir).ok()?;
+        let mut best: Option<(String, std::time::SystemTime)> = None;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // Only consider .jsonl session log files
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let stem = path.file_stem()?.to_string_lossy().to_string();
+            // Skip non-UUID filenames (e.g. if any other .jsonl exists)
+            if stem.len() != 36 || stem.chars().filter(|c| *c == '-').count() != 4 {
+                continue;
+            }
+            if let Ok(meta) = entry.metadata() {
+                if let Ok(mtime) = meta.modified() {
+                    match &best {
+                        None => best = Some((stem, mtime)),
+                        Some((_, prev_mtime)) if mtime > *prev_mtime => {
+                            best = Some((stem, mtime));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        best.map(|(id, _)| id)
     }
 
     pub fn is_sub_session(&self) -> bool {
@@ -396,15 +461,22 @@ impl Instance {
     }
 
     pub fn start_with_size(&mut self, size: Option<(u16, u16)>) -> Result<()> {
-        self.start_with_size_opts(size, false)
+        self.start_with_size_opts(size, false, None)
     }
 
     /// Start the session, optionally skipping on_launch hooks (e.g. when they
     /// already ran in the background creation poller).
+    ///
+    /// When `resume_id` is `Some` and the tool is `"claude"`, the session
+    /// launches with `--resume <id>`. When `resume_id` is `None` but
+    /// `self.claude_session_id` is `Some`, the session falls back to
+    /// `--continue`. The stored `claude_session_id` is cleared after a
+    /// successful start to avoid stale IDs on subsequent restarts.
     pub fn start_with_size_opts(
         &mut self,
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
+        resume_id: Option<&str>,
     ) -> Result<()> {
         let session = self.tmux_session()?;
 
@@ -467,6 +539,19 @@ impl Instance {
             }
         }
 
+        // Compute Claude-specific resume/continue flag (only for tool == "claude")
+        let resume_flag = if self.tool == "claude" {
+            if let Some(id) = resume_id {
+                Some(format!("--resume {}", id))
+            } else if self.claude_session_id.is_some() {
+                Some("--continue".to_string())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let cmd = if self.is_sandboxed() {
             let container = self.get_container_for_instance()?;
             // Run on_launch hooks inside the container
@@ -484,11 +569,14 @@ impl Instance {
             }
 
             let sandbox = self.sandbox_info.as_ref().unwrap();
-            let base_cmd = if self.extra_args.is_empty() {
+            let mut base_cmd = if self.extra_args.is_empty() {
                 self.get_tool_command().to_string()
             } else {
                 format!("{} {}", self.get_tool_command(), self.extra_args)
             };
+            if let Some(ref flag) = resume_flag {
+                base_cmd = format!("{} {}", base_cmd, flag);
+            }
             let mut tool_cmd = if self.is_yolo_mode() {
                 if let Some(ref yolo) = agent.and_then(|a| a.yolo.as_ref()) {
                     match yolo {
@@ -558,6 +646,9 @@ impl Instance {
                     if !self.extra_args.is_empty() {
                         cmd = format!("{} {}", cmd, self.extra_args);
                     }
+                    if let Some(ref flag) = resume_flag {
+                        cmd = format!("{} {}", cmd, flag);
+                    }
                     if self.is_yolo_mode() {
                         if let Some(ref yolo) = a.yolo {
                             match yolo {
@@ -577,6 +668,9 @@ impl Instance {
                 let mut cmd = self.command.clone();
                 if !self.extra_args.is_empty() {
                     cmd = format!("{} {}", cmd, self.extra_args);
+                }
+                if let Some(ref flag) = resume_flag {
+                    cmd = format!("{} {}", cmd, flag);
                 }
                 if self.is_yolo_mode() {
                     if let Some(ref yolo) = agent.and_then(|a| a.yolo.as_ref()) {
@@ -612,6 +706,11 @@ impl Instance {
 
         self.status = Status::Starting;
         self.last_start_time = Some(std::time::Instant::now());
+
+        // Clear stored Claude session ID after start to avoid stale IDs
+        if resume_flag.is_some() {
+            self.claude_session_id = None;
+        }
 
         Ok(())
     }
@@ -1618,5 +1717,184 @@ mod tests {
         assert_eq!(inst.title, "old-session");
         assert!(inst.idle_since.is_none());
         assert!(inst.last_accessed_at.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // claude_project_hash() tests (AC-01)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_claude_project_hash_canonical_path() {
+        // AC-01: claude_project_hash computes the project key correctly
+        let inst = Instance::new("test", "/tmp");
+        let hash = inst.claude_project_hash();
+        assert!(hash.is_some());
+        let key = hash.unwrap();
+        // /tmp may resolve to a symlink (e.g. /private/tmp on macOS)
+        let canonical = std::fs::canonicalize("/tmp")
+            .unwrap()
+            .to_string_lossy()
+            .replace('/', "-");
+        assert_eq!(key, canonical);
+    }
+
+    #[test]
+    fn test_claude_project_hash_nonexistent_path() {
+        // AC-01: non-existent path returns None
+        let inst = Instance::new("test", "/nonexistent/path/that/does/not/exist");
+        assert!(inst.claude_project_hash().is_none());
+    }
+
+    #[test]
+    fn test_claude_project_hash_format() {
+        // AC-01: the key starts with - (from leading /) and contains no /
+        let inst = Instance::new("test", "/tmp");
+        if let Some(key) = inst.claude_project_hash() {
+            assert!(key.starts_with('-'), "key should start with -: {}", key);
+            assert!(!key.contains('/'), "key should not contain /: {}", key);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // discover_claude_session_id() tests (AC-02)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_discover_claude_session_id_nonexistent_project() {
+        // AC-02: gracefully returns None for a project path with no Claude sessions
+        let inst = Instance::new("test", "/nonexistent/path/that/does/not/exist");
+        assert!(inst.discover_claude_session_id().is_none());
+    }
+
+    #[test]
+    fn test_discover_claude_session_id_with_temp_sessions() {
+        // AC-02: discovers the most recent session from a temp directory structure
+        let tmp = tempfile::tempdir().unwrap();
+        let project_path = tmp.path().to_str().unwrap();
+
+        // Create the Claude projects directory structure
+        let project_key = std::fs::canonicalize(project_path)
+            .unwrap()
+            .to_string_lossy()
+            .replace('/', "-");
+        let claude_dir = tmp
+            .path()
+            .join(".claude-test-home")
+            .join("projects")
+            .join(&project_key);
+        std::fs::create_dir_all(&claude_dir).unwrap();
+
+        // Create two fake session files
+        let older_id = "11111111-1111-1111-1111-111111111111";
+        let newer_id = "22222222-2222-2222-2222-222222222222";
+
+        std::fs::write(claude_dir.join(format!("{}.jsonl", older_id)), "old").unwrap();
+        // Ensure the second file has a later mtime
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::fs::write(claude_dir.join(format!("{}.jsonl", newer_id)), "new").unwrap();
+
+        // We can't directly test discover_claude_session_id because it hardcodes
+        // ~/.claude/projects, but we can test the underlying logic.
+        // Read the directory and find the newest .jsonl
+        let entries = std::fs::read_dir(&claude_dir).unwrap();
+        let mut best: Option<(String, std::time::SystemTime)> = None;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let stem = path.file_stem().unwrap().to_string_lossy().to_string();
+            if stem.len() != 36 || stem.chars().filter(|c| *c == '-').count() != 4 {
+                continue;
+            }
+            if let Ok(meta) = entry.metadata() {
+                if let Ok(mtime) = meta.modified() {
+                    match &best {
+                        None => best = Some((stem, mtime)),
+                        Some((_, prev_mtime)) if mtime > *prev_mtime => {
+                            best = Some((stem, mtime));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert_eq!(best.map(|(id, _)| id), Some(newer_id.to_string()));
+    }
+
+    #[test]
+    fn test_discover_claude_session_id_empty_dir() {
+        // AC-02: empty Claude project directory returns None
+        let tmp = tempfile::tempdir().unwrap();
+        let project_path = tmp.path().to_str().unwrap();
+        // The method looks at ~/.claude/projects/<key>, which doesn't
+        // exist for a temp dir, so this tests the None return path.
+        let inst = Instance::new("test", project_path);
+        // Will be None because ~/.claude/projects/<key> doesn't exist for a temp dir
+        assert!(inst.discover_claude_session_id().is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // claude_session_id backwards compatibility (AC-03)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_deserialize_instance_without_claude_session_id() {
+        // AC-03: session JSON without claude_session_id deserializes with None
+        let json = r#"{
+            "id": "abc123def456abcd",
+            "title": "old-session",
+            "project_path": "/tmp/test",
+            "command": "",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00Z"
+        }"#;
+        let inst: Instance = serde_json::from_str(json).unwrap();
+        assert!(inst.claude_session_id.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_instance_with_claude_session_id() {
+        // AC-03: session JSON with claude_session_id deserializes correctly
+        let json = r#"{
+            "id": "abc123def456abcd",
+            "title": "test-session",
+            "project_path": "/tmp/test",
+            "command": "",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00Z",
+            "claude_session_id": "11111111-1111-1111-1111-111111111111"
+        }"#;
+        let inst: Instance = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            inst.claude_session_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+    }
+
+    #[test]
+    fn test_claude_session_id_not_serialized_when_none() {
+        // AC-03: None claude_session_id is omitted from JSON (skip_serializing_if)
+        let inst = Instance::new("test", "/tmp/test");
+        let json = serde_json::to_string(&inst).unwrap();
+        assert!(
+            !json.contains("claude_session_id"),
+            "None claude_session_id should be omitted from JSON"
+        );
+    }
+
+    #[test]
+    fn test_claude_session_id_serialized_when_some() {
+        // AC-03: Some claude_session_id is present in JSON
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.claude_session_id = Some("test-id".to_string());
+        let json = serde_json::to_string(&inst).unwrap();
+        assert!(
+            json.contains("claude_session_id"),
+            "Some claude_session_id should be present in JSON"
+        );
+        assert!(json.contains("test-id"));
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -244,9 +244,12 @@ impl Instance {
             if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                 continue;
             }
-            let stem = path.file_stem()?.to_string_lossy().to_string();
-            // Skip non-UUID filenames (e.g. if any other .jsonl exists)
-            if stem.len() != 36 || stem.chars().filter(|c| *c == '-').count() != 4 {
+            let Some(stem_os) = path.file_stem() else {
+                continue;
+            };
+            let stem = stem_os.to_string_lossy().to_string();
+            // Skip non-UUID filenames: must be 36 chars, hex digits and hyphens only
+            if stem.len() != 36 || !stem.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
                 continue;
             }
             if let Ok(meta) = entry.metadata() {
@@ -468,10 +471,8 @@ impl Instance {
     /// already ran in the background creation poller).
     ///
     /// When `resume_id` is `Some` and the tool is `"claude"`, the session
-    /// launches with `--resume <id>`. When `resume_id` is `None` but
-    /// `self.claude_session_id` is `Some`, the session falls back to
-    /// `--continue`. The stored `claude_session_id` is cleared after a
-    /// successful start to avoid stale IDs on subsequent restarts.
+    /// launches with `--resume <id>`. The caller (`app.rs`) is responsible
+    /// for clearing the stored `claude_session_id` after a successful start.
     pub fn start_with_size_opts(
         &mut self,
         size: Option<(u16, u16)>,
@@ -539,15 +540,9 @@ impl Instance {
             }
         }
 
-        // Compute Claude-specific resume/continue flag (only for tool == "claude")
+        // Compute Claude-specific --resume flag (only for tool == "claude")
         let resume_flag = if self.tool == "claude" {
-            if let Some(id) = resume_id {
-                Some(format!("--resume {}", id))
-            } else if self.claude_session_id.is_some() {
-                Some("--continue".to_string())
-            } else {
-                None
-            }
+            resume_id.map(|id| format!("--resume {}", shell_escape(id)))
         } else {
             None
         };
@@ -706,11 +701,6 @@ impl Instance {
 
         self.status = Status::Starting;
         self.last_start_time = Some(std::time::Instant::now());
-
-        // Clear stored Claude session ID after start to avoid stale IDs
-        if resume_flag.is_some() {
-            self.claude_session_id = None;
-        }
 
         Ok(())
     }
@@ -1803,8 +1793,11 @@ mod tests {
             if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                 continue;
             }
-            let stem = path.file_stem().unwrap().to_string_lossy().to_string();
-            if stem.len() != 36 || stem.chars().filter(|c| *c == '-').count() != 4 {
+            let Some(stem_os) = path.file_stem() else {
+                continue;
+            };
+            let stem = stem_os.to_string_lossy().to_string();
+            if stem.len() != 36 || !stem.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
                 continue;
             }
             if let Ok(meta) = entry.metadata() {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -210,12 +210,13 @@ impl Instance {
     /// Compute the Claude Code project key for this session's `project_path`.
     ///
     /// Claude Code identifies projects by canonicalizing the path and replacing
-    /// each `/` with `-`. For example, `/home/user/my-project` becomes
-    /// `-home-user-my-project`. Returns `None` if the path cannot be canonicalized.
+    /// both `/` and `.` with `-`. For example, `/home/user/.config/my-project`
+    /// becomes `-home-user--config-my-project`. Returns `None` if the path
+    /// cannot be canonicalized.
     pub fn claude_project_hash(&self) -> Option<String> {
         std::fs::canonicalize(&self.project_path)
             .ok()
-            .map(|p| p.to_string_lossy().replace('/', "-"))
+            .map(|p| p.to_string_lossy().replace(['/', '.'], "-"))
     }
 
     /// Discover the most recent Claude Code session ID for this project.
@@ -1724,7 +1725,7 @@ mod tests {
         let canonical = std::fs::canonicalize("/tmp")
             .unwrap()
             .to_string_lossy()
-            .replace('/', "-");
+            .replace(['/', '.'], "-");
         assert_eq!(key, canonical);
     }
 
@@ -1737,12 +1738,35 @@ mod tests {
 
     #[test]
     fn test_claude_project_hash_format() {
-        // AC-01: the key starts with - (from leading /) and contains no /
+        // AC-01: the key starts with - (from leading /) and contains no / or .
         let inst = Instance::new("test", "/tmp");
         if let Some(key) = inst.claude_project_hash() {
             assert!(key.starts_with('-'), "key should start with -: {}", key);
             assert!(!key.contains('/'), "key should not contain /: {}", key);
+            assert!(!key.contains('.'), "key should not contain .: {}", key);
         }
+    }
+
+    #[test]
+    fn test_claude_project_hash_replaces_dots() {
+        // AC-01: dots in path components are replaced with -
+        let tmp = tempfile::tempdir().unwrap();
+        let dot_dir = tmp.path().join(".hidden-dir");
+        std::fs::create_dir_all(&dot_dir).unwrap();
+
+        let inst = Instance::new("test", dot_dir.to_str().unwrap());
+        let key = inst.claude_project_hash().unwrap();
+        assert!(
+            !key.contains('.'),
+            "dots should be replaced with -: {}",
+            key
+        );
+        // The dot from ".hidden-dir" should become "-hidden-dir"
+        assert!(
+            key.contains("-hidden-dir"),
+            "key should contain -hidden-dir: {}",
+            key
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1766,7 +1790,7 @@ mod tests {
         let project_key = std::fs::canonicalize(project_path)
             .unwrap()
             .to_string_lossy()
-            .replace('/', "-");
+            .replace(['/', '.'], "-");
         let claude_dir = tmp
             .path()
             .join(".claude-test-home")

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -580,6 +580,12 @@ impl App {
 
         let attach_result = self.with_raw_mode_disabled(terminal, || tmux_session.attach())?;
 
+        // Mark the session as accessed so the idle indicator clears
+        self.home.mutate_instance(session_id, |inst| {
+            inst.last_accessed_at = Some(chrono::Utc::now());
+        });
+        let _ = self.home.save();
+
         self.needs_redraw = true;
         crate::tmux::refresh_session_cache();
         self.home.reload()?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -570,10 +570,6 @@ impl App {
                 let discovered = instance.discover_claude_session_id();
                 if let Some(ref id) = discovered {
                     tracing::debug!(session_id, claude_session_id = %id, "discovered Claude session ID for resume");
-                    // Store the discovered ID in the instance for fallback use
-                    self.home.mutate_instance(session_id, |inst| {
-                        inst.claude_session_id = discovered.clone();
-                    });
                 }
                 discovered
             } else {
@@ -583,10 +579,6 @@ impl App {
             self.home
                 .set_instance_status(session_id, crate::session::Status::Starting);
             let mut inst = instance.clone();
-            // Sync the claude_session_id from the mutated instance
-            if let Some(stored) = self.home.get_instance(session_id) {
-                inst.claude_session_id = stored.claude_session_id.clone();
-            }
             if let Err(e) = inst.start_with_size_opts(size, skip_on_launch, resume_id.as_deref()) {
                 self.home
                     .set_instance_error(session_id, Some(e.to_string()));
@@ -595,12 +587,6 @@ impl App {
                 return Ok(());
             }
             self.home.set_instance_error(session_id, None);
-            // Clear stored Claude session ID after successful resume start
-            if resume_id.is_some() {
-                self.home.mutate_instance(session_id, |inst| {
-                    inst.claude_session_id = None;
-                });
-            }
         }
 
         let attach_result = self.with_raw_mode_disabled(terminal, || tmux_session.attach())?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -565,10 +565,29 @@ impl App {
             // Skip on_launch hooks if they already ran in the background creation poller
             let skip_on_launch = self.home.take_on_launch_hooks_ran(session_id);
 
+            // For Claude sessions, discover the latest session ID for --resume
+            let resume_id = if instance.tool == "claude" {
+                let discovered = instance.discover_claude_session_id();
+                if let Some(ref id) = discovered {
+                    tracing::debug!(session_id, claude_session_id = %id, "discovered Claude session ID for resume");
+                    // Store the discovered ID in the instance for fallback use
+                    self.home.mutate_instance(session_id, |inst| {
+                        inst.claude_session_id = discovered.clone();
+                    });
+                }
+                discovered
+            } else {
+                None
+            };
+
             self.home
                 .set_instance_status(session_id, crate::session::Status::Starting);
             let mut inst = instance.clone();
-            if let Err(e) = inst.start_with_size_opts(size, skip_on_launch) {
+            // Sync the claude_session_id from the mutated instance
+            if let Some(stored) = self.home.get_instance(session_id) {
+                inst.claude_session_id = stored.claude_session_id.clone();
+            }
+            if let Err(e) = inst.start_with_size_opts(size, skip_on_launch, resume_id.as_deref()) {
                 self.home
                     .set_instance_error(session_id, Some(e.to_string()));
                 self.home
@@ -576,6 +595,12 @@ impl App {
                 return Ok(());
             }
             self.home.set_instance_error(session_id, None);
+            // Clear stored Claude session ID after successful resume start
+            if resume_id.is_some() {
+                self.home.mutate_instance(session_id, |inst| {
+                    inst.claude_session_id = None;
+                });
+            }
         }
 
         let attach_result = self.with_raw_mode_disabled(terminal, || tmux_session.attach())?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -652,6 +652,12 @@ impl App {
 
         let attach_result = self.with_raw_mode_disabled(terminal, attach_fn)?;
 
+        // Mark the session as accessed so the idle indicator clears
+        self.home.mutate_instance(session_id, |inst| {
+            inst.last_accessed_at = Some(chrono::Utc::now());
+        });
+        let _ = self.home.save();
+
         self.needs_redraw = true;
         crate::tmux::refresh_session_cache();
         self.home.reload()?;

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 41;
+const DIALOG_HEIGHT: u16 = 42;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -48,6 +48,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("c", "Toggle container/host (sandbox)"),
                 ("D", "Diff view (git changes)"),
                 ("S", "TPM state panel (if .tpm)"),
+                ("F", "Fullscreen state panel"),
                 ("J/K", "Scroll state panel"),
                 ("H/L", "Resize list panel"),
                 ("o", "Cycle sort forward"),

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -53,7 +53,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("H/L", "Resize list panel"),
                 ("o", "Cycle sort forward"),
                 ("Ctrl+o", "Cycle sort backward"),
-                ("g", "Toggle group by project"),
+                ("g", "Cycle group mode"),
             ],
         ),
         (

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -734,9 +734,13 @@ impl HomeView {
                 self.state_panel_cache.scroll_offset =
                     self.state_panel_cache.scroll_offset.saturating_sub(3);
             }
+            KeyCode::Char('F') if self.show_state_panel => {
+                self.state_panel_fullscreen = !self.state_panel_fullscreen;
+            }
             KeyCode::Char('S') => {
                 if self.show_state_panel {
                     self.show_state_panel = false;
+                    self.state_panel_fullscreen = false;
                 } else if let Some(id) = self.selected_session.clone() {
                     if let Some(inst) = self.get_instance(&id).cloned() {
                         if super::state_panel::StatePanelCache::exists_for(&inst) {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -850,10 +850,10 @@ impl HomeView {
                         ));
                     }
                 } else if let Some(group_path) = &self.selected_group {
-                    if self.group_by == GroupByMode::Project {
+                    if matches!(self.group_by, GroupByMode::Project | GroupByMode::Tpm) {
                         self.info_dialog = Some(InfoDialog::new(
-                            "Cannot Modify Project Groups",
-                            "Project groups are automatic. Press 'g' to switch to manual grouping to manage groups.",
+                            "Cannot Modify Auto Groups",
+                            "These groups are automatic. Press 'g' to switch to manual grouping to manage groups.",
                         ));
                         return None;
                     }
@@ -907,10 +907,10 @@ impl HomeView {
                         ));
                     }
                 } else if let Some(group_path) = &self.selected_group {
-                    if self.group_by == GroupByMode::Project {
+                    if matches!(self.group_by, GroupByMode::Project | GroupByMode::Tpm) {
                         self.info_dialog = Some(InfoDialog::new(
-                            "Cannot Modify Project Groups",
-                            "Project groups are automatic. Press 'g' to switch to manual grouping to manage groups.",
+                            "Cannot Modify Auto Groups",
+                            "These groups are automatic. Press 'g' to switch to manual grouping to manage groups.",
                         ));
                         return None;
                     }
@@ -1120,7 +1120,7 @@ impl HomeView {
     }
 
     fn toggle_group_collapsed(&mut self, path: &str) {
-        if self.group_by == GroupByMode::Project {
+        if matches!(self.group_by, GroupByMode::Project | GroupByMode::Tpm) {
             let collapsed = self
                 .project_group_collapsed
                 .get(path)

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1069,6 +1069,7 @@ impl HomeView {
                     self.selected_group_profile = None;
                     if changed {
                         self.show_state_panel = false;
+                        self.state_panel_fullscreen = false;
                         self.state_panel_cache.reset_scroll();
                     }
                 }
@@ -1077,6 +1078,7 @@ impl HomeView {
                     self.selected_group = Some(path.clone());
                     self.selected_group_profile = self.profile_for_cursor(self.cursor);
                     self.show_state_panel = false;
+                    self.state_panel_fullscreen = false;
                 }
             }
         }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -231,6 +231,7 @@ pub struct HomeView {
 
     // TPM STATE.md panel
     pub(super) show_state_panel: bool,
+    pub(super) state_panel_fullscreen: bool,
     pub(super) state_panel_cache: state_panel::StatePanelCache,
 }
 
@@ -367,6 +368,7 @@ impl HomeView {
                 .and_then(|c| c.app_state.home_list_width)
                 .unwrap_or(35),
             show_state_panel: false,
+            state_panel_fullscreen: false,
             state_panel_cache: state_panel::StatePanelCache::default(),
         };
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1051,16 +1051,17 @@ impl HomeView {
         let grouped: Vec<Instance> = base_instances
             .into_iter()
             .map(|mut inst| {
+                // Clear any pre-existing group_path from Manual mode so
+                // non-children don't leak into spurious group headers.
+                inst.group_path = String::new();
                 if let Some(parent_id) = &inst.parent_session_id {
                     if let Some(title) = parent_titles.get(parent_id) {
-                        // Child session: group under parent's title
-                        inst.group_path = title.clone();
+                        // Child session: group under parent's title.
+                        // Sanitize `/` so GroupTree doesn't create nested groups
+                        // for titles like "feature/auth-refactor".
+                        inst.group_path = title.replace('/', " - ");
                     }
-                    // Orphan (parent_session_id points to non-existent session):
-                    // leave group_path empty so it appears ungrouped at top level
                 }
-                // Sessions without parent_session_id (including orchestrators)
-                // keep group_path empty and appear at top level
                 inst
             })
             .collect();

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -976,6 +976,9 @@ impl HomeView {
         if self.group_by == GroupByMode::Project {
             return self.build_flat_items_by_project();
         }
+        if self.group_by == GroupByMode::Tpm {
+            return self.build_flat_items_by_tpm();
+        }
 
         if let Some(profile) = &self.active_profile {
             let filtered: Vec<Instance> = self
@@ -1015,6 +1018,49 @@ impl HomeView {
             .into_iter()
             .map(|mut inst| {
                 inst.group_path = project_group_name(&inst);
+                inst
+            })
+            .collect();
+
+        let mut tree = GroupTree::new_with_groups(&grouped, &[]);
+        for (path, &collapsed) in &self.project_group_collapsed {
+            if collapsed {
+                tree.set_collapsed(path, true);
+            }
+        }
+        flatten_tree(&tree, &grouped, self.sort_order)
+    }
+
+    fn build_flat_items_by_tpm(&self) -> Vec<Item> {
+        let base_instances: Vec<Instance> = if let Some(profile) = &self.active_profile {
+            self.instances
+                .iter()
+                .filter(|i| i.source_profile == *profile)
+                .cloned()
+                .collect()
+        } else {
+            self.instances.clone()
+        };
+
+        // Build a lookup: parent_id -> parent title for resolving group names
+        let parent_titles: HashMap<String, String> = base_instances
+            .iter()
+            .map(|i| (i.id.clone(), i.title.clone()))
+            .collect();
+
+        let grouped: Vec<Instance> = base_instances
+            .into_iter()
+            .map(|mut inst| {
+                if let Some(parent_id) = &inst.parent_session_id {
+                    if let Some(title) = parent_titles.get(parent_id) {
+                        // Child session: group under parent's title
+                        inst.group_path = title.clone();
+                    }
+                    // Orphan (parent_session_id points to non-existent session):
+                    // leave group_path empty so it appears ungrouped at top level
+                }
+                // Sessions without parent_session_id (including orchestrators)
+                // keep group_path empty and appear at top level
                 inst
             })
             .collect();

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -499,10 +499,26 @@ impl HomeView {
                 if should_update {
                     let new_status = update.status;
                     let new_error = update.last_error;
+                    let mut idle_changed = false;
                     self.mutate_instance(&update.id, |inst| {
+                        let old = inst.status;
                         inst.status = new_status;
                         inst.last_error = new_error;
+
+                        // Track idle transitions for the "needs attention" indicator
+                        if old != Status::Idle && new_status == Status::Idle {
+                            inst.idle_since = Some(chrono::Utc::now());
+                            idle_changed = true;
+                        } else if old == Status::Idle && new_status != Status::Idle {
+                            inst.idle_since = None;
+                            idle_changed = true;
+                        }
                     });
+
+                    // Persist idle_since changes so they survive TUI restarts
+                    if idle_changed {
+                        let _ = self.save();
+                    }
 
                     if let Some(old) = old_status {
                         if old != new_status {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -56,6 +56,19 @@ fn project_group_name(inst: &Instance) -> String {
         })
 }
 
+/// Update `idle_since` when a session's status transitions to or from Idle.
+/// Must be called BEFORE overwriting `inst.status` with `new_status`.
+fn apply_idle_transition(inst: &mut Instance, new_status: crate::session::Status) {
+    use crate::session::Status;
+
+    let old = inst.status;
+    if old != Status::Idle && new_status == Status::Idle {
+        inst.idle_since = Some(chrono::Utc::now());
+    } else if old == Status::Idle && new_status != Status::Idle {
+        inst.idle_since = None;
+    }
+}
+
 pub(super) struct GroupRenameContext {
     pub(super) old_path: String,
     pub(super) old_profile: String,
@@ -417,6 +430,10 @@ impl HomeView {
                     inst.last_error = prev.last_error.clone();
                     inst.last_error_check = prev.last_error_check;
                     inst.last_start_time = prev.last_start_time;
+                    // Preserve idle tracking fields so a failed save()
+                    // doesn't let reload() overwrite them with stale disk values
+                    inst.last_accessed_at = prev.last_accessed_at;
+                    inst.idle_since = prev.idle_since;
                 }
             }
             // Rebuild this profile's tree from disk, preserving any collapsed
@@ -499,26 +516,11 @@ impl HomeView {
                 if should_update {
                     let new_status = update.status;
                     let new_error = update.last_error;
-                    let mut idle_changed = false;
                     self.mutate_instance(&update.id, |inst| {
-                        let old = inst.status;
+                        apply_idle_transition(inst, new_status);
                         inst.status = new_status;
                         inst.last_error = new_error;
-
-                        // Track idle transitions for the "needs attention" indicator
-                        if old != Status::Idle && new_status == Status::Idle {
-                            inst.idle_since = Some(chrono::Utc::now());
-                            idle_changed = true;
-                        } else if old == Status::Idle && new_status != Status::Idle {
-                            inst.idle_since = None;
-                            idle_changed = true;
-                        }
                     });
-
-                    // Persist idle_since changes so they survive TUI restarts
-                    if idle_changed {
-                        let _ = self.save();
-                    }
 
                     if let Some(old) = old_status {
                         if old != new_status {
@@ -1096,7 +1098,10 @@ impl HomeView {
     }
 
     pub fn set_instance_status(&mut self, id: &str, status: crate::session::Status) {
-        self.mutate_instance(id, |inst| inst.status = status);
+        self.mutate_instance(id, |inst| {
+            apply_idle_transition(inst, status);
+            inst.status = status;
+        });
     }
 
     pub fn save(&self) -> anyhow::Result<()> {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1055,11 +1055,13 @@ impl HomeView {
                 // non-children don't leak into spurious group headers.
                 inst.group_path = String::new();
                 if let Some(parent_id) = &inst.parent_session_id {
-                    if let Some(title) = parent_titles.get(parent_id) {
-                        // Child session: group under parent's title.
-                        // Sanitize `/` so GroupTree doesn't create nested groups
-                        // for titles like "feature/auth-refactor".
-                        inst.group_path = title.replace('/', " - ");
+                    if parent_id != &inst.id {
+                        if let Some(title) = parent_titles.get(parent_id) {
+                            // Child session: group under parent's title.
+                            // Sanitize `/` so GroupTree doesn't create nested groups
+                            // for titles like "feature/auth-refactor".
+                            inst.group_path = title.replace('/', " - ");
+                        }
                     }
                 }
                 inst

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -473,6 +473,17 @@ impl HomeView {
             style
         };
         line_spans.push(Span::styled(format!("{} ", icon), icon_style));
+
+        // Idle-attention dot: prepend a colored dot before the title for sessions
+        // that went idle after the user last viewed them.
+        if let Item::Session { id, .. } = item {
+            if let Some(inst) = self.get_instance(id) {
+                if inst.needs_attention() {
+                    line_spans.push(Span::styled("● ", Style::default().fg(theme.waiting)));
+                }
+            }
+        }
+
         line_spans.push(Span::styled(
             text.into_owned(),
             if is_selected { style.bold() } else { style },

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -228,10 +228,10 @@ impl HomeView {
     }
 
     fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let group_suffix = if self.group_by == GroupByMode::Project {
-            " (by project)"
-        } else {
-            ""
+        let group_suffix = match self.group_by {
+            GroupByMode::Project => " (by project)",
+            GroupByMode::Tpm => " (by TPM)",
+            _ => "",
         };
         let title = match self.view_mode {
             ViewMode::Agent => format!(

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -115,20 +115,36 @@ impl HomeView {
                 }
             }
 
-            let right_chunks = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
-                .split(chunks[1]);
-
-            self.render_preview(frame, right_chunks[0], theme);
             let scroll = self.state_panel_cache.scroll_offset;
-            super::state_panel::render_state_panel(
-                frame,
-                right_chunks[1],
-                &self.state_panel_cache.content,
-                theme,
-                scroll,
-            );
+            let fullscreen = self.state_panel_fullscreen;
+
+            if fullscreen {
+                // Fullscreen: state panel takes the entire right area
+                super::state_panel::render_state_panel(
+                    frame,
+                    chunks[1],
+                    &self.state_panel_cache.content,
+                    theme,
+                    scroll,
+                    true,
+                );
+            } else {
+                // Split mode: preview + state panel side by side
+                let right_chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                    .split(chunks[1]);
+
+                self.render_preview(frame, right_chunks[0], theme);
+                super::state_panel::render_state_panel(
+                    frame,
+                    right_chunks[1],
+                    &self.state_panel_cache.content,
+                    theme,
+                    scroll,
+                    false,
+                );
+            }
         } else {
             // Refresh cache in background even when panel is hidden (for poll)
             if self.show_state_panel {
@@ -903,10 +919,18 @@ impl HomeView {
         // Show S: State hint when a TPM session is selected (uses cached path, no fs stat)
         if self.selected_session.is_some() && self.state_panel_cache.has_state_file() {
             if self.show_state_panel {
+                let fullscreen_hint = if self.state_panel_fullscreen {
+                    " Split "
+                } else {
+                    " Full "
+                };
                 spans.extend([
                     Span::styled("│", sep_style),
                     Span::styled(" S", key_style),
                     Span::styled(" Close ", desc_style),
+                    Span::styled("│", sep_style),
+                    Span::styled(" F", key_style),
+                    Span::styled(fullscreen_hint, desc_style),
                     Span::styled("│", sep_style),
                     Span::styled(" J/K", key_style),
                     Span::styled(" Scroll ", desc_style),

--- a/src/tui/home/state_panel.rs
+++ b/src/tui/home/state_panel.rs
@@ -133,6 +133,22 @@ impl StatePanelCache {
     }
 }
 
+/// Pad a string to `target` display-width columns by appending spaces.
+/// If `s` is already >= `target` display columns, returns it unchanged.
+fn pad_to_display_width(s: &str, target: usize) -> String {
+    let current = UnicodeWidthStr::width(s);
+    if current >= target {
+        s.to_string()
+    } else {
+        let padding = target - current;
+        let mut result = s.to_string();
+        for _ in 0..padding {
+            result.push(' ');
+        }
+        result
+    }
+}
+
 /// Render the STATE.md panel into the given area.
 pub(in crate::tui) fn render_state_panel(
     frame: &mut Frame,
@@ -140,12 +156,18 @@ pub(in crate::tui) fn render_state_panel(
     content: &str,
     theme: &Theme,
     scroll_offset: usize,
+    fullscreen: bool,
 ) {
+    let title = if fullscreen {
+        " TPM State (full) "
+    } else {
+        " TPM State "
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme.accent))
-        .title(" TPM State ")
+        .title(title)
         .title_style(Style::default().fg(theme.accent).bold())
         .padding(Padding::horizontal(1));
 
@@ -320,7 +342,7 @@ fn compute_table_col_widths(table_lines: &[&str], max_width: usize) -> Vec<usize
             widths.resize(cells.len(), 0);
         }
         for (j, cell) in cells.iter().enumerate() {
-            widths[j] = widths[j].max(cell.len());
+            widths[j] = widths[j].max(UnicodeWidthStr::width(cell.as_str()));
         }
     }
 
@@ -345,8 +367,11 @@ fn render_table_header(cells: &[String], col_widths: &[usize], theme: &Theme) ->
     let mut spans: Vec<Span<'static>> = Vec::new();
 
     for (j, cell) in cells.iter().enumerate() {
-        let w = col_widths.get(j).copied().unwrap_or(cell.len());
-        let padded = format!("{:<width$}", cell, width = w);
+        let w = col_widths
+            .get(j)
+            .copied()
+            .unwrap_or_else(|| UnicodeWidthStr::width(cell.as_str()));
+        let padded = pad_to_display_width(cell, w);
 
         spans.push(Span::styled(
             padded,
@@ -369,8 +394,11 @@ fn render_table_row(cells: &[String], col_widths: &[usize], theme: &Theme) -> Li
     let mut spans: Vec<Span<'static>> = Vec::new();
 
     for (j, cell) in cells.iter().enumerate() {
-        let w = col_widths.get(j).copied().unwrap_or(cell.len());
-        let padded = format!("{:<width$}", cell, width = w);
+        let w = col_widths
+            .get(j)
+            .copied()
+            .unwrap_or_else(|| UnicodeWidthStr::width(cell.as_str()));
+        let padded = pad_to_display_width(cell, w);
 
         let style = status_color_for_cell(cell, theme);
         spans.push(Span::styled(padded, style));
@@ -688,5 +716,85 @@ mod tests {
         assert_eq!(byte_offset_for_width("\u{4f60}x", 2), 3);
         // Width larger than string returns full length
         assert_eq!(byte_offset_for_width("hi", 10), 2);
+    }
+
+    #[test]
+    fn test_compute_col_widths_emoji() {
+        // Table with emoji and varying display widths
+        let table = vec![
+            "| Status | Task |",
+            "|---|---|",
+            "| \u{2705} | task-01 |",
+            "| implementing | task-02 |",
+        ];
+        let widths = compute_table_col_widths(&table, 80);
+        // col 0: max(width("Status")=6, width("✅")=1, width("implementing")=12) = 12
+        // col 1: max(width("Task")=4, width("task-01")=7, width("task-02")=7) = 7
+        assert_eq!(widths, vec![12, 7]);
+    }
+
+    #[test]
+    fn test_pad_to_display_width() {
+        // ASCII padding
+        assert_eq!(pad_to_display_width("foo", 6), "foo   ");
+
+        // Emoji: ✅ has display width of 1 (per unicode_width)
+        let padded_emoji = pad_to_display_width("\u{2705}", 4);
+        assert_eq!(UnicodeWidthStr::width(padded_emoji.as_str()), 4);
+
+        // CJK: 日本 = 2 chars, each 2 columns = 4 display cols; pad to 6
+        let padded_cjk = pad_to_display_width("\u{65E5}\u{672C}", 6);
+        assert_eq!(UnicodeWidthStr::width(padded_cjk.as_str()), 6);
+
+        // Already at or beyond target: returned unchanged
+        assert_eq!(pad_to_display_width("hello", 3), "hello");
+        assert_eq!(pad_to_display_width("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_table_pipes_align() {
+        // Build a table with mixed ASCII/emoji content, render it, and
+        // verify that the │ separators appear at the same character offset
+        // in every row.
+        let content =
+            "| Status | Task |\n|---|---|\n| \u{2705} | task-01 |\n| implementing | task-02 |\n";
+        let theme = Theme::default();
+        let lines = parse_state_md(content, &theme, 80);
+        // Header + 2 data rows
+        assert_eq!(lines.len(), 3);
+
+        // Extract pipe (│ = U+2502) offsets from each rendered line
+        let mut all_offsets: Vec<Vec<usize>> = Vec::new();
+        for line in &lines {
+            let mut offsets = Vec::new();
+            let mut col = 0usize;
+            for span in &line.spans {
+                for ch in span.content.chars() {
+                    if ch == '\u{2502}' {
+                        offsets.push(col);
+                    }
+                    col += unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+                }
+            }
+            all_offsets.push(offsets);
+        }
+
+        // All rows must have the same number of │ at the same offsets
+        assert!(
+            !all_offsets.is_empty(),
+            "should have at least one rendered row"
+        );
+        let expected = &all_offsets[0];
+        assert!(
+            !expected.is_empty(),
+            "header row should have at least one pipe separator"
+        );
+        for (i, offsets) in all_offsets.iter().enumerate() {
+            assert_eq!(
+                offsets, expected,
+                "Row {} pipe offsets {:?} differ from header {:?}",
+                i, offsets, expected
+            );
+        }
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2568,3 +2568,10 @@ fn test_project_group_name_handles_trailing_slash() {
     let inst = Instance::new("test", "/home/user/my-project/");
     assert_eq!(project_group_name(&inst), "my-project");
 }
+
+#[test]
+#[serial]
+fn test_state_panel_fullscreen_defaults_to_false() {
+    let env = create_test_env_empty();
+    assert!(!env.view.state_panel_fullscreen);
+}

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2541,7 +2541,7 @@ fn test_apply_creation_results_returns_session_id() {
 fn test_project_group_name_uses_last_path_segment() {
     use super::project_group_name;
 
-    let mut inst = Instance::new("test", "/home/user/my-project");
+    let inst = Instance::new("test", "/home/user/my-project");
     assert_eq!(project_group_name(&inst), "my-project");
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2790,3 +2790,41 @@ fn test_tpm_group_by_slash_in_title_no_nested_groups() {
         "slash in title should be sanitized"
     );
 }
+
+/// Self-referential parent_session_id must not group a session under itself.
+#[test]
+#[serial]
+fn test_tpm_group_by_self_referential_stays_ungrouped() {
+    use crate::session::config::GroupByMode;
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new("test").unwrap();
+
+    let mut session = Instance::new("self-ref", "/tmp/sr");
+    session.parent_session_id = Some(session.id.clone());
+
+    let instances = vec![session];
+    storage.save(&instances).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = GroupByMode::Tpm;
+    view.flat_items = view.build_flat_items();
+
+    let groups: Vec<_> = view
+        .flat_items
+        .iter()
+        .filter(|i| matches!(i, Item::Group { .. }))
+        .collect();
+    assert_eq!(
+        groups.len(),
+        0,
+        "self-referential session must not create a group"
+    );
+    assert_eq!(view.flat_items.len(), 1);
+    if let Item::Session { depth, .. } = &view.flat_items[0] {
+        assert_eq!(*depth, 0, "self-referential session should be at top level");
+    } else {
+        panic!("expected a session item, got a group");
+    }
+}

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2575,3 +2575,24 @@ fn test_state_panel_fullscreen_defaults_to_false() {
     let env = create_test_env_empty();
     assert!(!env.view.state_panel_fullscreen);
 }
+
+#[test]
+#[serial]
+fn test_state_panel_fullscreen_resets_on_session_switch() {
+    let mut env = create_test_env_with_sessions(3);
+    // Simulate: user has panel open in fullscreen on session 0
+    env.view.cursor = 0;
+    env.view.update_selected();
+    env.view.show_state_panel = true;
+    env.view.state_panel_fullscreen = true;
+
+    // Navigate to session 1
+    env.view.handle_key(key(KeyCode::Down));
+
+    // Both flags must be cleared when switching sessions
+    assert!(!env.view.show_state_panel);
+    assert!(
+        !env.view.state_panel_fullscreen,
+        "state_panel_fullscreen should reset when switching sessions"
+    );
+}

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -323,6 +323,8 @@ fn test_g_key_cycles_group_by() {
     env.view.handle_key(key(KeyCode::Char('g')));
     assert_eq!(env.view.group_by, GroupByMode::Project);
     env.view.handle_key(key(KeyCode::Char('g')));
+    assert_eq!(env.view.group_by, GroupByMode::Tpm);
+    env.view.handle_key(key(KeyCode::Char('g')));
     assert_eq!(env.view.group_by, GroupByMode::Manual);
 }
 
@@ -2595,4 +2597,124 @@ fn test_state_panel_fullscreen_resets_on_session_switch() {
         !env.view.state_panel_fullscreen,
         "state_panel_fullscreen should reset when switching sessions"
     );
+}
+
+// --- TPM group-by mode tests ---
+
+fn create_test_env_with_tpm_sessions() -> TestEnv {
+    use crate::session::config::GroupByMode;
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new("test").unwrap();
+
+    // Create orchestrator (no parent_session_id)
+    let orchestrator = Instance::new("my-orchestrator", "/tmp/orch");
+    let orch_id = orchestrator.id.clone();
+
+    // Create 3 child sessions pointing to the orchestrator
+    let mut child1 = Instance::new("impl-auth", "/tmp/c1");
+    child1.parent_session_id = Some(orch_id.clone());
+    let mut child2 = Instance::new("impl-db", "/tmp/c2");
+    child2.parent_session_id = Some(orch_id.clone());
+    let mut child3 = Instance::new("impl-ui", "/tmp/c3");
+    child3.parent_session_id = Some(orch_id);
+
+    let instances = vec![orchestrator, child1, child2, child3];
+    storage.save(&instances).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = GroupByMode::Tpm;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+    TestEnv { _temp: temp, view }
+}
+
+/// AC-03: build_flat_items_by_tpm() produces correct grouping
+/// (1 group + 3 children + orchestrator ungrouped)
+#[test]
+#[serial]
+fn test_tpm_group_by_produces_correct_grouping() {
+    let env = create_test_env_with_tpm_sessions();
+
+    let groups: Vec<_> = env
+        .view
+        .flat_items
+        .iter()
+        .filter(|i| matches!(i, Item::Group { .. }))
+        .collect();
+    assert_eq!(groups.len(), 1, "should have exactly 1 group header");
+
+    if let Item::Group {
+        name,
+        session_count,
+        ..
+    } = &groups[0]
+    {
+        assert_eq!(name, "my-orchestrator", "group name should be parent title");
+        assert_eq!(*session_count, 3, "group should count 3 direct children");
+    }
+
+    let sessions: Vec<_> = env
+        .view
+        .flat_items
+        .iter()
+        .filter(|i| matches!(i, Item::Session { .. }))
+        .collect();
+    assert_eq!(sessions.len(), 4, "should have 4 sessions total");
+
+    // First item is the ungrouped orchestrator at depth 0
+    if let Item::Session { depth, .. } = &env.view.flat_items[0] {
+        assert_eq!(*depth, 0, "orchestrator should be at depth 0");
+    } else {
+        panic!("first item should be a session (orchestrator)");
+    }
+}
+
+/// AC-04: orphaned sub-sessions (parent_session_id pointing to nonexistent ID)
+/// stay ungrouped at top level.
+#[test]
+#[serial]
+fn test_tpm_group_by_orphan_stays_ungrouped() {
+    use crate::session::config::GroupByMode;
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new("test").unwrap();
+
+    let standalone = Instance::new("standalone", "/tmp/s");
+    let mut orphan = Instance::new("orphan-session", "/tmp/o");
+    orphan.parent_session_id = Some("nonexistent-id-12345".to_string());
+
+    let instances = vec![standalone, orphan];
+    storage.save(&instances).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = GroupByMode::Tpm;
+    view.flat_items = view.build_flat_items();
+
+    let groups: Vec<_> = view
+        .flat_items
+        .iter()
+        .filter(|i| matches!(i, Item::Group { .. }))
+        .collect();
+    assert_eq!(
+        groups.len(),
+        0,
+        "no groups should exist for orphan sessions"
+    );
+
+    let sessions: Vec<_> = view
+        .flat_items
+        .iter()
+        .filter(|i| matches!(i, Item::Session { .. }))
+        .collect();
+    assert_eq!(sessions.len(), 2, "both sessions should appear ungrouped");
+
+    // Both at depth 0
+    for item in &view.flat_items {
+        if let Item::Session { depth, .. } = item {
+            assert_eq!(*depth, 0, "orphan and standalone should both be at depth 0");
+        }
+    }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2718,3 +2718,75 @@ fn test_tpm_group_by_orphan_stays_ungrouped() {
         }
     }
 }
+
+/// E-01 regression: sessions with a pre-existing group_path from Manual mode
+/// must not leak that group into Tpm mode.
+#[test]
+#[serial]
+fn test_tpm_group_by_clears_preexisting_group_path() {
+    use crate::session::config::GroupByMode;
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new("test").unwrap();
+
+    let mut session = Instance::new("has-manual-group", "/tmp/g");
+    session.group_path = "my-manual-group".to_string();
+
+    let instances = vec![session];
+    storage.save(&instances).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = GroupByMode::Tpm;
+    view.flat_items = view.build_flat_items();
+
+    let groups: Vec<_> = view
+        .flat_items
+        .iter()
+        .filter(|i| matches!(i, Item::Group { .. }))
+        .collect();
+    assert_eq!(
+        groups.len(),
+        0,
+        "manual group_path must not leak into Tpm mode"
+    );
+}
+
+/// E-02 regression: orchestrator titles containing `/` must not create
+/// nested group hierarchies.
+#[test]
+#[serial]
+fn test_tpm_group_by_slash_in_title_no_nested_groups() {
+    use crate::session::config::GroupByMode;
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new("test").unwrap();
+
+    let orchestrator = Instance::new("feature/auth-refactor", "/tmp/orch");
+    let orch_id = orchestrator.id.clone();
+
+    let mut child = Instance::new("child-task", "/tmp/c");
+    child.parent_session_id = Some(orch_id);
+
+    let instances = vec![orchestrator, child];
+    storage.save(&instances).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = GroupByMode::Tpm;
+    view.flat_items = view.build_flat_items();
+
+    let groups: Vec<_> = view
+        .flat_items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Group { name, .. } => Some(name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(groups.len(), 1, "should have exactly 1 group, not nested");
+    assert_eq!(
+        groups[0], "feature - auth-refactor",
+        "slash in title should be sanitized"
+    );
+}

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -417,6 +417,12 @@ last_seen_version = "{}"
         &self.stub_path
     }
 
+    /// Path to the tmux socket used by this harness. Useful for creating
+    /// auxiliary tmux sessions on the same server that AoE will check.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
     /// Create and return a test project directory inside the temp home.
     pub fn project_path(&self) -> PathBuf {
         let p = self.home_dir.path().join("test-project");

--- a/tests/e2e/idle_highlight.rs
+++ b/tests/e2e/idle_highlight.rs
@@ -1,0 +1,160 @@
+//! E2E tests for idle session highlighting (issue #21).
+//!
+//! Verifies the "needs attention" dot indicator appears for sessions that went
+//! idle after the user last viewed them, and disappears once the session is
+//! accessed.
+
+use serial_test::serial;
+use std::path::Path;
+use std::process::Command;
+
+use crate::harness::{require_tmux, TuiTestHarness};
+
+/// The session ID used in all tests. Chosen to be a valid 16-char hex string.
+const SESSION_ID: &str = "aabbccdd11223344";
+
+/// Compute the tmux session name AoE would use for the test session.
+/// Format: aoe_{sanitized_title}_{first 8 chars of id}
+fn tmux_session_name() -> String {
+    format!("aoe_idle-session_{}", &SESSION_ID[..8])
+}
+
+/// Pre-create a tmux session on the harness's socket so AoE's status poller
+/// sees it as alive. Runs `sleep 300` so the pane stays alive.
+fn create_backing_tmux_session(socket: &Path) {
+    let name = tmux_session_name();
+    let _ = Command::new("tmux")
+        .args(["-S"])
+        .arg(socket)
+        .args(["kill-session", "-t", &name])
+        .output();
+    let output = Command::new("tmux")
+        .args(["-S"])
+        .arg(socket)
+        .args([
+            "new-session",
+            "-d",
+            "-s",
+            &name,
+            "-x",
+            "80",
+            "-y",
+            "24",
+            "sleep",
+            "300",
+        ])
+        .output()
+        .expect("create backing tmux session");
+    assert!(
+        output.status.success(),
+        "Failed to create backing tmux session: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn kill_backing_tmux_session(socket: &Path) {
+    let name = tmux_session_name();
+    let _ = Command::new("tmux")
+        .args(["-S"])
+        .arg(socket)
+        .args(["kill-session", "-t", &name])
+        .output();
+}
+
+/// Write a sessions.json with one session that has idle_since set but no
+/// last_accessed_at, so the TUI should show the attention indicator.
+fn seed_idle_session(h: &TuiTestHarness) {
+    let config_dir = if cfg!(target_os = "linux") {
+        h.home_path()
+            .join(".config/agent-of-empires/profiles/default")
+    } else {
+        h.home_path().join(".agent-of-empires/profiles/default")
+    };
+    std::fs::create_dir_all(&config_dir).expect("create profile dir");
+
+    let sessions_json = format!(
+        r#"[
+        {{
+            "id": "{SESSION_ID}",
+            "title": "idle-session",
+            "project_path": "/tmp/test",
+            "command": "",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00Z",
+            "idle_since": "2026-04-25T10:00:00Z"
+        }}
+    ]"#
+    );
+    std::fs::write(config_dir.join("sessions.json"), sessions_json).expect("write sessions.json");
+}
+
+/// Write a sessions.json where last_accessed_at > idle_since, so the indicator
+/// should NOT appear.
+fn seed_accessed_session(h: &TuiTestHarness) {
+    let config_dir = if cfg!(target_os = "linux") {
+        h.home_path()
+            .join(".config/agent-of-empires/profiles/default")
+    } else {
+        h.home_path().join(".agent-of-empires/profiles/default")
+    };
+
+    let sessions_json = format!(
+        r#"[
+        {{
+            "id": "{SESSION_ID}",
+            "title": "idle-session",
+            "project_path": "/tmp/test",
+            "command": "",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00Z",
+            "idle_since": "2026-04-25T10:00:00Z",
+            "last_accessed_at": "2026-04-25T11:00:00Z"
+        }}
+    ]"#
+    );
+    std::fs::write(config_dir.join("sessions.json"), sessions_json).expect("write sessions.json");
+}
+
+/// AC-04 part 1: idle session shows the attention indicator dot.
+/// Pre-creates a backing tmux session on the harness's socket so the status
+/// poller sees it as alive and keeps the Idle status (and idle_since) intact.
+#[test]
+#[serial]
+fn test_idle_session_shows_attention_indicator() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("idle_indicator");
+    seed_idle_session(&h);
+
+    // Must create backing session on the harness socket AFTER spawn_tui(),
+    // because spawn_tui() starts the tmux server on that socket.
+    h.spawn_tui();
+    create_backing_tmux_session(h.socket_path());
+
+    h.wait_for("Agent of Empires");
+    h.wait_for("idle-session");
+    h.assert_screen_contains("●");
+
+    kill_backing_tmux_session(h.socket_path());
+}
+
+/// AC-04 part 2: once last_accessed_at > idle_since, the indicator is gone.
+#[test]
+#[serial]
+fn test_accessed_session_hides_attention_indicator() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("idle_no_indicator");
+    seed_accessed_session(&h);
+
+    h.spawn_tui();
+    create_backing_tmux_session(h.socket_path());
+
+    h.wait_for("Agent of Empires");
+    h.wait_for("idle-session");
+    h.assert_screen_not_contains("●");
+
+    kill_backing_tmux_session(h.socket_path());
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -21,6 +21,7 @@ pub(crate) mod helpers;
 mod cli;
 mod errors;
 mod events;
+mod idle_highlight;
 mod new_session;
 mod profile_picker;
 mod profile_template;

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -30,6 +30,7 @@ mod send_keys;
 mod tpm;
 mod tpm_artifacts;
 mod tpm_config;
+mod tpm_group_by;
 mod tpm_prompt_injection;
 mod tpm_tier;
 mod tpm_tui_create;

--- a/tests/e2e/tpm_group_by.rs
+++ b/tests/e2e/tpm_group_by.rs
@@ -1,0 +1,84 @@
+//! E2E test for TPM group-by mode (issue #30, AC-05).
+//!
+//! Seeds an orchestrator + 2 sub-sessions, presses `g` twice to reach Tpm mode,
+//! and verifies the group header is visible with the correct session count.
+
+use serial_test::serial;
+
+use crate::harness::{require_tmux, TuiTestHarness};
+
+/// Return the config dir under the harness's isolated home.
+fn config_dir(h: &TuiTestHarness) -> std::path::PathBuf {
+    if cfg!(target_os = "linux") {
+        h.home_path().join(".config/agent-of-empires")
+    } else {
+        h.home_path().join(".agent-of-empires")
+    }
+}
+
+/// Seed an orchestrator session + 2 child sessions with parent_session_id.
+fn seed_tpm_sessions(h: &TuiTestHarness) {
+    let profile_dir = config_dir(h).join("profiles/default");
+    std::fs::create_dir_all(&profile_dir).expect("create default profile dir");
+
+    let sessions = r#"[
+        {
+            "id": "orch-001",
+            "title": "TPM Orchestrator",
+            "project_path": "/tmp/tpm-test",
+            "command": "",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00Z"
+        },
+        {
+            "id": "child-001",
+            "title": "impl-auth",
+            "project_path": "/tmp/tpm-test",
+            "command": "",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2026-01-01T00:01:00Z",
+            "parent_session_id": "orch-001"
+        },
+        {
+            "id": "child-002",
+            "title": "impl-db",
+            "project_path": "/tmp/tpm-test",
+            "command": "",
+            "tool": "claude",
+            "status": "idle",
+            "created_at": "2026-01-01T00:02:00Z",
+            "parent_session_id": "orch-001"
+        }
+    ]"#;
+    std::fs::write(profile_dir.join("sessions.json"), sessions).expect("write sessions.json");
+}
+
+/// AC-05: press g twice to reach Tpm mode, verify group header visible with count.
+#[test]
+#[serial]
+fn tpm_group_by_shows_orchestrator_group_with_count() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("tpm_group_by");
+    seed_tpm_sessions(&h);
+
+    h.spawn_tui();
+    h.wait_for("Agent of Empires");
+
+    // Default group mode for existing users (has_seen_welcome=true) is Manual.
+    // Press g once -> Project, press g again -> Tpm.
+    h.send_keys("g");
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    h.send_keys("g");
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // In Tpm mode, the title bar should show "(by TPM)"
+    h.wait_for("by TPM");
+
+    // The group header should show the orchestrator's title and child count
+    h.assert_screen_contains("TPM Orchestrator");
+    // The group header includes the count of children (2)
+    h.assert_screen_contains("2");
+}

--- a/tests/e2e/tpm_group_by.rs
+++ b/tests/e2e/tpm_group_by.rs
@@ -2,8 +2,10 @@
 //!
 //! Seeds an orchestrator + 2 sub-sessions, presses `g` twice to reach Tpm mode,
 //! and verifies the group header is visible with the correct session count.
+//! Also tests expand/collapse behavior via arrow keys.
 
 use serial_test::serial;
+use std::time::Duration;
 
 use crate::harness::{require_tmux, TuiTestHarness};
 
@@ -55,7 +57,9 @@ fn seed_tpm_sessions(h: &TuiTestHarness) {
     std::fs::write(profile_dir.join("sessions.json"), sessions).expect("write sessions.json");
 }
 
-/// AC-05: press g twice to reach Tpm mode, verify group header visible with count.
+/// AC-05: press g twice to reach Tpm mode, verify group header visible with
+/// count and child sessions. Then test collapse (Left) hides children and
+/// expand (Right) restores them.
 #[test]
 #[serial]
 fn tpm_group_by_shows_orchestrator_group_with_count() {
@@ -70,15 +74,41 @@ fn tpm_group_by_shows_orchestrator_group_with_count() {
     // Default group mode for existing users (has_seen_welcome=true) is Manual.
     // Press g once -> Project, press g again -> Tpm.
     h.send_keys("g");
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    std::thread::sleep(Duration::from_millis(500));
     h.send_keys("g");
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    std::thread::sleep(Duration::from_millis(500));
 
     // In Tpm mode, the title bar should show "(by TPM)"
     h.wait_for("by TPM");
 
     // The group header should show the orchestrator's title and child count
     h.assert_screen_contains("TPM Orchestrator");
-    // The group header includes the count of children (2)
     h.assert_screen_contains("2");
+
+    // Children should be visible (group expanded by default)
+    h.assert_screen_contains("impl-auth");
+    h.assert_screen_contains("impl-db");
+
+    // Navigate cursor to the group header row. The orchestrator session is at
+    // index 0 (ungrouped, top), then group header at index 1. Press Down once.
+    h.send_keys("Down");
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Collapse the group (Left arrow)
+    h.send_keys("Left");
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Children should disappear
+    h.assert_screen_not_contains("impl-auth");
+    h.assert_screen_not_contains("impl-db");
+    // Group header should still be visible
+    h.assert_screen_contains("TPM Orchestrator");
+
+    // Expand the group (Right arrow)
+    h.send_keys("Right");
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Children should reappear
+    h.assert_screen_contains("impl-auth");
+    h.assert_screen_contains("impl-db");
 }

--- a/tests/e2e/tui_state_panel.rs
+++ b/tests/e2e/tui_state_panel.rs
@@ -150,3 +150,106 @@ fn state_panel_cjk_unicode_content_renders() {
     h.wait_for_timeout("\u{72B6}\u{614B}", Duration::from_secs(5));
     h.assert_screen_contains("\u{65E5}\u{672C}\u{8A9E}\u{30C6}\u{30B9}\u{30C8}");
 }
+
+// ===========================================================================
+// AC-07: Fullscreen toggle and preview hiding
+// ===========================================================================
+
+#[test]
+#[serial]
+fn state_panel_fullscreen_toggle_hides_preview() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("state_panel_fs");
+
+    let project = h.project_path();
+    let tpm_dir = project.join(".tpm");
+    std::fs::create_dir_all(&tpm_dir).expect("create .tpm dir");
+    std::fs::write(
+        tpm_dir.join("STATE.md"),
+        "## Tasks\n\n| Task | Status |\n|---|---|\n| task-01 | done |\n| task-02 | implementing |\n",
+    )
+    .expect("write STATE.md");
+
+    seed_session(&h, "FS Toggle", &project);
+
+    h.spawn_tui();
+    h.wait_for("Agent of Empires");
+    h.wait_for("FS Toggle");
+
+    // Open state panel in split mode
+    h.send_keys("S");
+    std::thread::sleep(Duration::from_millis(800));
+    h.wait_for_timeout("task-01", Duration::from_secs(5));
+    // Preview title should be visible in split mode
+    h.assert_screen_contains("Preview");
+
+    // Press Shift+F to go fullscreen
+    h.send_keys("F");
+    std::thread::sleep(Duration::from_millis(500));
+
+    // (a) State panel content still visible
+    h.assert_screen_contains("task-01");
+    // (b) Preview title should be gone (fullscreen hides preview)
+    h.assert_screen_not_contains("Preview");
+
+    // Press Shift+F again to restore split mode
+    h.send_keys("F");
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Preview reappears alongside state panel content
+    h.assert_screen_contains("Preview");
+    h.assert_screen_contains("task-01");
+}
+
+// ===========================================================================
+// AC-08: Fullscreen reset on close
+// ===========================================================================
+
+#[test]
+#[serial]
+fn state_panel_fullscreen_resets_on_close() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("state_panel_fs_reset");
+
+    let project = h.project_path();
+    let tpm_dir = project.join(".tpm");
+    std::fs::create_dir_all(&tpm_dir).expect("create .tpm dir");
+    std::fs::write(
+        tpm_dir.join("STATE.md"),
+        "## Wave 1\n\n| Task | Status |\n|---|---|\n| task-01 | done |\n",
+    )
+    .expect("write STATE.md");
+
+    seed_session(&h, "FS Reset", &project);
+
+    h.spawn_tui();
+    h.wait_for("Agent of Empires");
+    h.wait_for("FS Reset");
+
+    // Open panel, go fullscreen
+    h.send_keys("S");
+    std::thread::sleep(Duration::from_millis(800));
+    h.wait_for_timeout("task-01", Duration::from_secs(5));
+    h.send_keys("F");
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Verify fullscreen (no Preview)
+    h.assert_screen_not_contains("Preview");
+
+    // Close with S
+    h.send_keys("S");
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Panel content should be hidden
+    h.wait_for_absent("TPM State", Duration::from_secs(5));
+
+    // Re-open with S: should be in split mode (not fullscreen)
+    h.send_keys("S");
+    std::thread::sleep(Duration::from_millis(800));
+    h.wait_for_timeout("task-01", Duration::from_secs(5));
+
+    // Preview should be visible (split mode, not fullscreen)
+    h.assert_screen_contains("Preview");
+}


### PR DESCRIPTION
## Summary

Four TUI enhancements implemented via TPM prod-tier workflow (4 waves, 14 commits):

- **#19** STATE.md panel: fullscreen toggle (Shift+F) + markdown table column alignment fix (Unicode-width-aware padding)
- **#21** Idle session highlighting: yellow `●` dot for sessions that went idle after user's last visit (`idle_since` + `last_accessed_at` tracking)
- **#27** Claude Code session ID auto-resume: discovers session ID from `~/.claude/projects/`, injects `--resume <id>` on crash recovery
- **#30** TPM group-by mode: `g` key cycles Manual → Project → Tpm, collapsible parent sessions via `parent_session_id`

## Stats

- 16 files changed, +1437 / -39 lines
- 14 new unit tests, 5 new E2E tests
- All 1403 tests pass, 0 clippy warnings

## Test plan

- [x] `cargo test` — 1403 passed, 0 failed
- [x] `cargo test --test e2e` — 101 passed (includes new feature E2E tests)
- [x] `cargo clippy` — 0 warnings
- [x] `cargo build` — success
- [x] QA validator pass (27/28 ACs verified, 1 manual-only)

Closes #19, closes #21, closes #27, closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)